### PR TITLE
Ref/contexts using index

### DIFF
--- a/include/Commander/Contexts/ContainsCommandContext.hpp
+++ b/include/Commander/Contexts/ContainsCommandContext.hpp
@@ -4,27 +4,15 @@
 #define CONTAINS_COMMAND_CONTEXT_HPP
 
 #include "../def/Repository.hpp"
-#include "Commander/Contexts/CommandContext.hpp"
+#include "Commander/Contexts/IndexedCommandContext.hpp"
 
 using std::string;
 
-class ContainsCommandContext : public CommandContext {
+class ContainsCommandContext : public IndexedCommandContext {
 public:
-    Repository repository;
-    int setIndex;
     int key;
 
-    /**
-     * @brief Constructs a context for a "contains" command operation.
-     *
-     * This constructor initializes the context with the given repository, set index,
-     * and key to be checked, storing all necessary information for executing the command.
-     *
-     * @param repository The repository containing the sets.
-     * @param setIndex The index of the set within the repository.
-     * @param key The key to search for in the specified set.
-     */
-    ContainsCommandContext(const Repository repository, int setIndex, int key);
+    ContainsCommandContext(const Repository repository, int index, int key);
 };
 
 #endif

--- a/include/Commander/Contexts/EmptyCommandContext.hpp
+++ b/include/Commander/Contexts/EmptyCommandContext.hpp
@@ -2,15 +2,12 @@
 #define EMPTY_COMMAND_CONTEXT_HPP
 
 #include "../def/Repository.hpp"
-#include "Commander/Contexts/CommandContext.hpp"
+#include "Commander/Contexts/IndexedCommandContext.hpp"
 
 using std::string;
 
-class EmptyCommandContext : public CommandContext {
+class EmptyCommandContext : public IndexedCommandContext {
 public:
-  Repository repository;
-  int index;
-
   /**
    * @brief Context builder to empty command
    *

--- a/include/Commander/Contexts/IndexedCommandContext.hpp
+++ b/include/Commander/Contexts/IndexedCommandContext.hpp
@@ -4,13 +4,33 @@
 #include "../def/Repository.hpp"
 #include "Commander/Contexts/CommandContext.hpp"
 
+/**
+ * @class IndexedCommandContext
+ * @brief Represents a command context that includes an index and a repository.
+ * 
+ * This class extends the CommandContext and adds additional information
+ * such as an index to identify a specific command and a repository
+ * to provide context for the command's execution.
+ */
 class IndexedCommandContext : public CommandContext {
 public:
-	int index;
-	Repository repository;
+    /**
+     * @brief The index of the command within a sequence or collection.
+     */
+    int index;
 
-	IndexedCommandContext(const Repository repository, int index)
-		: repository(repository), index(index) {}
+    /**
+     * @brief The repository associated with the command's context.
+     */
+    Repository repository;
+
+    /**
+     * @brief Constructs an IndexedCommandContext with the given repository and index.
+     * @param repository The repository associated with the command.
+     * @param index The index of the command.
+     */
+    IndexedCommandContext(const Repository repository, int index)
+        : repository(repository), index(index) {}
 };
 
 #endif

--- a/include/Commander/Contexts/IndexedCommandContext.hpp
+++ b/include/Commander/Contexts/IndexedCommandContext.hpp
@@ -1,0 +1,16 @@
+#ifndef INDEXED_COMMAND_HPP
+#define INDEXED_COMMAND_HPP
+
+#include "../def/Repository.hpp"
+#include "Commander/Contexts/CommandContext.hpp"
+
+class IndexedCommandContext : public CommandContext {
+public:
+	int index;
+	Repository repository;
+
+	IndexedCommandContext(const Repository repository, int index)
+		: repository(repository), index(index) {}
+};
+
+#endif

--- a/src/Commander/Commands/ContainsCommand.cpp
+++ b/src/Commander/Commands/ContainsCommand.cpp
@@ -9,7 +9,7 @@ void ContainsCommand::execute(CommandContext *context) const {
   auto *ctx = dynamic_cast<ContainsCommandContext *>(context);
 
   if (ctx) {
-    int index = ctx->setIndex, key = ctx->key;
+    int index = ctx->index, key = ctx->key;
 
     cout << "O conjunto " << index << (ctx->repository[index].set->contains(key) ? " " : " nao ") << "contem o valor " << key << '\n';
   }

--- a/src/Commander/Contexts/ContainsCommandContext.cpp
+++ b/src/Commander/Contexts/ContainsCommandContext.cpp
@@ -1,5 +1,5 @@
 
 #include "Commander/Contexts/ContainsCommandContext.hpp"
 
-ContainsCommandContext::ContainsCommandContext(const Repository repository, int setIndex, int key)
-    : repository(repository), setIndex(setIndex), key(key) {}
+ContainsCommandContext::ContainsCommandContext(const Repository repository, int index, int key)
+    : IndexedCommandContext(repository, index), key(key) {}

--- a/src/Commander/Contexts/EmptyCommandContext.cpp
+++ b/src/Commander/Contexts/EmptyCommandContext.cpp
@@ -1,4 +1,4 @@
 #include "Commander/Contexts/EmptyCommandContext.hpp"
 
 EmptyCommandContext::EmptyCommandContext(const Repository repository, int index)
-	: repository(repository), index(index) {}
+	: IndexedCommandContext(repository, index) {}


### PR DESCRIPTION
This pull request refactors the command context hierarchy by introducing an `IndexedCommandContext` base class to reduce code duplication and improve maintainability. The most notable changes involve modifying existing context classes to inherit from this new base class and updating the corresponding constructors and usages.

### Refactoring of Command Contexts:

* **Introduction of `IndexedCommandContext`**:
  - Added a new base class `IndexedCommandContext` in `include/Commander/Contexts/IndexedCommandContext.hpp`, which encapsulates common properties (`repository` and `index`) and their initialization.

* **Modification of `ContainsCommandContext`**:
  - Changed `ContainsCommandContext` to inherit from `IndexedCommandContext` instead of `CommandContext`. Removed duplicate properties (`repository` and `setIndex`) and updated the constructor to delegate initialization to the base class. [[1]](diffhunk://#diff-41d5f2c5fcf13b1cdf30e996f241e76e77474c3df998bf4e2c3c00cfdb31740dL7-R15) [[2]](diffhunk://#diff-6c7c2b482018e951e45ce69d6de32b7aae3a4d829170975a7d53b93e76bfb1ccL4-R5)

* **Modification of `EmptyCommandContext`**:
  - Changed `EmptyCommandContext` to inherit from `IndexedCommandContext` instead of `CommandContext`. Removed duplicate properties (`repository` and `index`) and updated the constructor to delegate initialization to the base class. [[1]](diffhunk://#diff-235c0d8aa7682bfe792f18b05480d8c1681893a7c88472222003d72019fedc48L5-L13) [[2]](diffhunk://#diff-aba69ab7acca9ad5c608ed241cd2b176aafbc69a7d573deeadc17eaa486c3c73L4-R4)

### Updates to Command Execution:

* **Adjustment in `ContainsCommand` Execution Logic**:
  - Updated the `ContainsCommand::execute` method to use the `index` property from the new `IndexedCommandContext` base class instead of the removed `setIndex` property.