### PR TITLE
(feat): new command adde

### DIFF
--- a/include/Commander/Commands/SizeCommand.hpp
+++ b/include/Commander/Commands/SizeCommand.hpp
@@ -1,0 +1,27 @@
+#ifndef SIZE_COMMAND_HPP
+#define SIZE_COMMAND_HPP
+
+#include <iostream>
+
+using std::string;
+using std::cout;
+
+#include "Commander/Commands/Command.hpp"
+#include "Commander/Contexts/SizeCommandContext.hpp"
+
+class SizeCommand : public Command {
+public:
+	/*
+	 * @brief SizeCommand constructor
+	 */
+	SizeCommand(const string& name, const string& description);
+
+	/*
+	 * @brief SizeCommand execution function
+	 * 
+	 * @param context Command context
+	 */
+	void execute(CommandContext *context) const override;
+};
+
+#endif

--- a/include/Commander/Contexts/SizeCommandContext.hpp
+++ b/include/Commander/Contexts/SizeCommandContext.hpp
@@ -1,0 +1,19 @@
+#ifndef SIZE_COMMAND_CONTEXT_HPP
+#define SIZE_COMMAND_CONTEXT_HPP
+
+#include "../def/Repository.hpp"
+#include "Commander/Contexts/IndexedCommandContext.hpp"
+
+using std::string;
+
+class SizeCommandContext : public IndexedCommandContext {
+public:
+  /**
+   * @brief Context builder to size command
+   *
+   * @param repository DI for data from the running system
+   */
+  SizeCommandContext(const Repository repository, int index);
+};
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,7 @@
 #include "Commander/Commands/ShowCommand.hpp"
 #include "Commander/Commands/ContainsCommand.hpp"
 #include "Commander/Commands/EmptyCommand.hpp"
+#include "Commander/Commands/SizeCommand.hpp"
 #include "Commander/Invoker/CommandInvoker.hpp"
 
 #include "Utils/Validation/ValidateRepositoryNotEmpty.hpp"
@@ -43,6 +44,7 @@ int main() {
 	ShowCommand showCommand("show", "mostra os conjuntos do sistema");
 	ContainsCommand containsCommand("contains", "verifica se um conjunto do sistema possui um valor especificado");
 	EmptyCommand emptyCommand("empty", "verifica se um conjunto do sistema esta vazio");
+	SizeCommand sizeCommand("size", "extrai o tamanho de um conjunto do sistema");
 	
 	invoker.registerCommand(
 		createCommand.getName(), &createCommand, [&sets]() -> CommandContext * {
@@ -87,6 +89,16 @@ int main() {
 			int index = promptValidIndex(sets, PromptIndexSet);
 
 			return new EmptyCommandContext(sets, index);
+		}
+	);
+
+	invoker.registerCommand(
+		sizeCommand.getName(), &sizeCommand, [&sets]() -> CommandContext * {
+			ValidateRepositoryNotEmpty(sets);
+
+			int index = promptValidIndex(sets, PromptIndexSet);
+
+			return new SizeCommandContext(sets, index);
 		}
 	);
 

--- a/src/Commander/Commands/SizeCommand.cpp
+++ b/src/Commander/Commands/SizeCommand.cpp
@@ -11,6 +11,6 @@ void SizeCommand::execute(CommandContext *context) const {
   	const Repository repo = ctx->repository;
   	int index = ctx->index;
 
-    cout << "O tamanho do conjunto " << index << " eh " << ctx->repository[index].set->size() << '\n';
+    cout << "O tamanho do conjunto " << index << " eh " << repo[index].set->size() << '\n';
   }
 }

--- a/src/Commander/Commands/SizeCommand.cpp
+++ b/src/Commander/Commands/SizeCommand.cpp
@@ -1,0 +1,16 @@
+#include "Commander/Commands/SizeCommand.hpp"
+
+SizeCommand::SizeCommand(const string &name,
+                                     const string &description)
+    : Command(name, description) {}
+
+void SizeCommand::execute(CommandContext *context) const {
+  auto *ctx = dynamic_cast<SizeCommandContext *>(context);
+
+  if (ctx) {
+  	const Repository repo = ctx->repository;
+  	int index = ctx->index;
+
+    cout << "O tamanho do conjunto " << index << " eh " << ctx->repository[index].set->size() << '\n';
+  }
+}

--- a/src/Commander/Contexts/SizeCommandContext.cpp
+++ b/src/Commander/Contexts/SizeCommandContext.cpp
@@ -1,0 +1,4 @@
+#include "Commander/Contexts/SizeCommandContext.hpp"
+
+SizeCommandContext::SizeCommandContext(const Repository repository, int index)
+	: IndexedCommandContext(repository, index) {}


### PR DESCRIPTION
This pull request introduces a new `SizeCommand` feature to the project, which allows users to retrieve the size of a specific set within the system. The changes include the implementation of the `SizeCommand` class, its context class, and integration into the command invoker in `main.cpp`.

### New Feature: `SizeCommand`

* **Implementation of `SizeCommand`**:
  - Added the `SizeCommand` class in `include/Commander/Commands/SizeCommand.hpp` and implemented its functionality in `src/Commander/Commands/SizeCommand.cpp`. This command retrieves and prints the size of a specified set in the repository. [[1]](diffhunk://#diff-78107d7d8d992485aa3cb3db7b25f398197671d06692cc6846e4fffbc1e8eb96R1-R27) [[2]](diffhunk://#diff-b2448f27952fde24c37dbe3bec7a46e6b404d95155bce862410c4e141f2849f2R1-R16)

* **Context for `SizeCommand`**:
  - Introduced the `SizeCommandContext` class in `include/Commander/Contexts/SizeCommandContext.hpp` and implemented its constructor in `src/Commander/Contexts/SizeCommandContext.cpp`. This context provides the necessary data (repository and index) for the `SizeCommand`. [[1]](diffhunk://#diff-1623eaec66ab51132e3e6494bcb8943d50e0422a868b03a6eec1fea1b1a784b5R1-R19) [[2]](diffhunk://#diff-11a7c31a26aab74ddc826a3365d6f2fa1818e5db44f64612c41b0f6499ef5101R1-R4)

### Integration into the Command System

* **Registration in `main.cpp`**:
  - Registered the `SizeCommand` in the `CommandInvoker` and added logic to validate the repository and prompt for a valid set index before executing the command. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR47) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR95-R104)

* **Header inclusion**:
  - Included the `SizeCommand` header in `main.cpp` to enable its usage.