### PR TITLE
(feat): new abstraction added

### DIFF
--- a/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
+++ b/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
@@ -1,0 +1,34 @@
+#ifndef DOUBLE_INDEXED_COMMAND_HPP
+#define DOUBLE_INDEXED_COMMAND_HPP
+
+#include "../def/ConstRepository.hpp"
+#include "Commander/Contexts/CommandContext.hpp"
+
+/**
+ * @class DoubleIndexedCommandContext
+ * @brief Represents a command context that includes two indexes and a
+ * repository.
+ *
+ * This class extends the CommandContext and adds additional information
+ * such as two indexes to identify a specific command and a repository
+ * to provide context for the command's execution.
+ */
+class DoubleIndexedCommandContext : public CommandContext {
+public:
+  ConstRepository repository;
+  int index1;
+  int index2;
+
+  /**
+   * @brief Constructs an DoubleIndexedCommandContext with the given repository
+   * and indexes.
+   * @param repository The repository associated with the command.
+   * @param index1 The first index of the command.
+   * @param index2 The second index of the command.
+   */
+  DoubleIndexedCommandContext(ConstRepository repository, int index1,
+                              int index2)
+      : repository(repository), index1(index1), index2(index2) {}
+};
+
+#endif

--- a/include/Commander/Contexts/SwapCommandContext.hpp
+++ b/include/Commander/Contexts/SwapCommandContext.hpp
@@ -2,25 +2,22 @@
 #define SWAP_COMMAND_CONTEXT
 
 #include "../def/ConstRepository.hpp"
-#include "Commander/Contexts/CommandContext.hpp"
+#include "Commander/Contexts/DoubleIndexedCommandContext.hpp"
 
-class SwapCommandContext : public CommandContext {
+class SwapCommandContext : public DoubleIndexedCommandContext {
 public:
-    ConstRepository repository;
-    int index1;
-    int index2;
-
-    /**
-    * @brief Constructs a context for a "swap" command operation.
-    *
-    * This constructor initializes the context with a constant reference to the repository
-    * and the two indexes of the sets to be swapped.
-    *
-    * @param repository The constant reference to the repository containing the sets.
-    * @param index1 The index of the first set to be swapped.
-    * @param index2 The index of the second set to be swapped.
-    */
-    SwapCommandContext(ConstRepository repository, int index1, int index2);
+  /**
+   * @brief Constructs a context for a "swap" command operation.
+   *
+   * This constructor initializes the context with a constant reference to the
+   * repository and the two indexes of the sets to be swapped.
+   *
+   * @param repository The constant reference to the repository containing the
+   * sets.
+   * @param index1 The index of the first set to be swapped.
+   * @param index2 The index of the second set to be swapped.
+   */
+  SwapCommandContext(ConstRepository repository, int index1, int index2);
 };
 
 #endif

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -397,7 +397,7 @@ public:
    * both the current set and the given set `T` into it, and returns `U` as
    * the union of the two sets.
    *
-   * @param T The set to union with the current set.
+   * @param set The set to union with the current set.
    * @return Set A new set containing all unique elements from both sets.
    */
   Set unionSet(const Set &set) const;

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -212,7 +212,7 @@ private:
    * @param U Reference to the set into which keys from the subtree will be
    * inserted.
    */
-  void insertSubtree(const Set &T, Set &U) const;
+  void insertSubtree(Node *T, Set &U) const;
 
   /**
    * @brief Creates the union of two subtrees into the target set.
@@ -225,7 +225,7 @@ private:
    * @param t2 Pointer to the root of the second subtree.
    * @param U Reference to the set where the union of keys will be stored.
    */
-  void unionSet(const Set &t1, const Set &t2, Set &U) const;
+  void unionSet(Node *t1, Node *t2, Set &U) const;
 
 public:
   /**
@@ -400,7 +400,7 @@ public:
    * @param T The set to union with the current set.
    * @return Set A new set containing all unique elements from both sets.
    */
-  void unionSet(const Set &set) const;
+  Set unionSet(const Set &set) const;
 
 #ifdef TEST_MODE
   // Retorna a raiz da árvore (para fins de teste)

--- a/src/Commander/Contexts/SwapCommandContext.cpp
+++ b/src/Commander/Contexts/SwapCommandContext.cpp
@@ -1,4 +1,5 @@
 #include "Commander/Contexts/SwapCommandContext.hpp"
 
-SwapCommandContext::SwapCommandContext(ConstRepository repository, int index1, int index2)
-    : repository(repository), index1(index1), index2(index2) {}
+SwapCommandContext::SwapCommandContext(ConstRepository repository, int index1,
+                                       int index2)
+    : DoubleIndexedCommandContext(repository, index1, index2) {}

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -326,7 +326,7 @@ int Set::successor(int key) const {
 	return successor->key;	
 }
 
-void Set::unionSet(const Set& T) const {
+Set Set::unionSet(const Set& T) const {
 	Set U;
 	unionSet(root, T.root, U);
 	return U;


### PR DESCRIPTION
This pull request introduces several changes, focusing on improving code reusability, simplifying method signatures, and enhancing functionality. The most significant updates include the addition of a new `DoubleIndexedCommandContext` class, refactoring of the `SwapCommandContext` to inherit from it, and modifications to the `Set` class to streamline its methods and improve their return types.

### Context Refactoring:

* Added a new `DoubleIndexedCommandContext` class to encapsulate shared functionality for command contexts requiring two indexes and a repository. This class simplifies code reuse and provides a clear structure for related contexts (`include/Commander/Contexts/DoubleIndexedCommandContext.hpp`).
* Refactored `SwapCommandContext` to inherit from `DoubleIndexedCommandContext`, removing redundant fields and delegating constructor logic to the parent class. This reduces duplication and leverages the new shared context (`include/Commander/Contexts/SwapCommandContext.hpp`, `src/Commander/Contexts/SwapCommandContext.cpp`). [[1]](diffhunk://#diff-a49b6cadefb044da282fb49f701a3b918775c2fdcd940859b83bc2a900699598L5-R16) [[2]](diffhunk://#diff-ede7c404e484fdc0a1f0f5dceb778be2a7e04ad565650c6786e0f35328c512f7L3-R5)

### `Set` Class Enhancements:

* Updated the `insertSubtree` and `unionSet` methods to accept `Node*` parameters instead of `Set` references, improving flexibility and reducing unnecessary object dependencies (`include/Set/Set.hpp`). [[1]](diffhunk://#diff-9d36b5a7d015fe5a3d87ad5ef59367a99bbe53c647d6fcb1e9704ccf2d136dbfL215-R215) [[2]](diffhunk://#diff-9d36b5a7d015fe5a3d87ad5ef59367a99bbe53c647d6fcb1e9704ccf2d136dbfL228-R228)
* Changed the `unionSet` method to return a `Set` object instead of `void`, making it more intuitive and functional by directly providing the result of the union operation (`include/Set/Set.hpp`, `src/Set/Set.cpp`). [[1]](diffhunk://#diff-9d36b5a7d015fe5a3d87ad5ef59367a99bbe53c647d6fcb1e9704ccf2d136dbfL403-R403) [[2]](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8L329-R329)