### PR TITLE
(ref): giving greater flexibility to the command

### DIFF
--- a/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
+++ b/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
@@ -13,6 +13,7 @@
  * such as two indexes to identify a specific command and a repository
  * to provide context for the command's execution.
  */
+ template <typename R>
 class DoubleIndexedCommandContext : public CommandContext {
 public:
   ConstRepository repository;
@@ -26,7 +27,7 @@ public:
    * @param index1 The first index of the command.
    * @param index2 The second index of the command.
    */
-  DoubleIndexedCommandContext(ConstRepository repository, int index1,
+  DoubleIndexedCommandContext(R repository, int index1,
                               int index2)
       : repository(repository), index1(index1), index2(index2) {}
 };

--- a/include/Commander/Contexts/SwapCommandContext.hpp
+++ b/include/Commander/Contexts/SwapCommandContext.hpp
@@ -4,7 +4,7 @@
 #include "../def/ConstRepository.hpp"
 #include "Commander/Contexts/DoubleIndexedCommandContext.hpp"
 
-class SwapCommandContext : public DoubleIndexedCommandContext {
+class SwapCommandContext : public DoubleIndexedCommandContext<ConstRepository> {
 public:
   /**
    * @brief Constructs a context for a "swap" command operation.


### PR DESCRIPTION
This pull request introduces a template parameter to the `DoubleIndexedCommandContext` class to improve its flexibility and updates its usage in the `SwapCommandContext` class accordingly. The most important changes involve the addition of the template parameter, updates to the constructor, and the explicit specialization of the template in the derived class.

### Template parameterization of `DoubleIndexedCommandContext`:

* [`include/Commander/Contexts/DoubleIndexedCommandContext.hpp`](diffhunk://#diff-c6bb564ff5827d57bb5415a2f84ca5cd583ae53c016ff8c5fd38aa09bd336ed7R16): Added a template parameter `<typename R>` to the `DoubleIndexedCommandContext` class, allowing it to work with different repository types.
* [`include/Commander/Contexts/DoubleIndexedCommandContext.hpp`](diffhunk://#diff-c6bb564ff5827d57bb5415a2f84ca5cd583ae53c016ff8c5fd38aa09bd336ed7L29-R30): Updated the constructor of `DoubleIndexedCommandContext` to use the template parameter `R` for the repository type instead of the fixed `ConstRepository` type.

### Updates to `SwapCommandContext`:

* [`include/Commander/Contexts/SwapCommandContext.hpp`](diffhunk://#diff-a49b6cadefb044da282fb49f701a3b918775c2fdcd940859b83bc2a900699598L7-R7): Modified `SwapCommandContext` to explicitly specialize `DoubleIndexedCommandContext` with `ConstRepository`, ensuring compatibility with the new template structure.