### PR TITLE
Feat/union

### DIFF
--- a/include/Commander/Commands/UnionCommand.hpp
+++ b/include/Commander/Commands/UnionCommand.hpp
@@ -15,7 +15,7 @@ public:
    * @brief Constructs a UnionCommand with the given name and description.
    *
    * Initializes the base Command class using the provided name and description,
-   * setting up the command to perform a swap operation between two sets.
+   * setting up the command to perform a union operation between two sets.
    *
    * @param name The name of the command.
    * @param description A brief description of what the command does.

--- a/include/Commander/Commands/UnionCommand.hpp
+++ b/include/Commander/Commands/UnionCommand.hpp
@@ -1,0 +1,28 @@
+#ifndef UNION_COMMAND_HPP
+#define UNION_COMMAND_HPP
+
+#include <iostream>
+
+#include "Commander/Commands/Command.hpp"
+#include "Commander/Contexts/UnionCommandContext.hpp"
+#include "Utils/Tools/FormatOrigin.hpp"
+
+using std::cout;
+
+class UnionCommand : public Command {
+public:
+  /**
+   * @brief Constructs a UnionCommand with the given name and description.
+   *
+   * Initializes the base Command class using the provided name and description,
+   * setting up the command to perform a swap operation between two sets.
+   *
+   * @param name The name of the command.
+   * @param description A brief description of what the command does.
+   */
+  UnionCommand(const string &name, const string &description);
+
+  void execute(CommandContext *context) const override;
+};
+
+#endif

--- a/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
+++ b/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
@@ -1,0 +1,34 @@
+#ifndef DOUBLE_INDEXED_COMMAND_HPP
+#define DOUBLE_INDEXED_COMMAND_HPP
+
+#include "../def/ConstRepository.hpp"
+#include "Commander/Contexts/CommandContext.hpp"
+
+/**
+ * @class DoubleIndexedCommandContext
+ * @brief Represents a command context that includes two indexes and a
+ * repository.
+ *
+ * This class extends the CommandContext and adds additional information
+ * such as two indexes to identify a specific command and a repository
+ * to provide context for the command's execution.
+ */
+class DoubleIndexedCommandContext : public CommandContext {
+public:
+  ConstRepository repository;
+  int index1;
+  int index2;
+
+  /**
+   * @brief Constructs an DoubleIndexedCommandContext with the given repository
+   * and indexes.
+   * @param repository The repository associated with the command.
+   * @param index1 The first index of the command.
+   * @param index2 The second index of the command.
+   */
+  DoubleIndexedCommandContext(ConstRepository repository, int index1,
+                              int index2)
+      : repository(repository), index1(index1), index2(index2) {}
+};
+
+#endif

--- a/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
+++ b/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
@@ -1,7 +1,6 @@
 #ifndef DOUBLE_INDEXED_COMMAND_HPP
 #define DOUBLE_INDEXED_COMMAND_HPP
 
-#include "../def/ConstRepository.hpp"
 #include "Commander/Contexts/CommandContext.hpp"
 
 /**
@@ -16,7 +15,7 @@
  template <typename R>
 class DoubleIndexedCommandContext : public CommandContext {
 public:
-  ConstRepository repository;
+  R repository;
   int index1;
   int index2;
 

--- a/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
+++ b/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
@@ -13,6 +13,7 @@
  * such as two indexes to identify a specific command and a repository
  * to provide context for the command's execution.
  */
+ template <typename R>
 class DoubleIndexedCommandContext : public CommandContext {
 public:
   ConstRepository repository;
@@ -26,7 +27,7 @@ public:
    * @param index1 The first index of the command.
    * @param index2 The second index of the command.
    */
-  DoubleIndexedCommandContext(ConstRepository repository, int index1,
+  DoubleIndexedCommandContext(R repository, int index1,
                               int index2)
       : repository(repository), index1(index1), index2(index2) {}
 };

--- a/include/Commander/Contexts/SwapCommandContext.hpp
+++ b/include/Commander/Contexts/SwapCommandContext.hpp
@@ -4,7 +4,7 @@
 #include "../def/ConstRepository.hpp"
 #include "Commander/Contexts/DoubleIndexedCommandContext.hpp"
 
-class SwapCommandContext : public DoubleIndexedCommandContext {
+class SwapCommandContext : public DoubleIndexedCommandContext<ConstRepository> {
 public:
   /**
    * @brief Constructs a context for a "swap" command operation.

--- a/include/Commander/Contexts/SwapCommandContext.hpp
+++ b/include/Commander/Contexts/SwapCommandContext.hpp
@@ -2,25 +2,22 @@
 #define SWAP_COMMAND_CONTEXT
 
 #include "../def/ConstRepository.hpp"
-#include "Commander/Contexts/CommandContext.hpp"
+#include "Commander/Contexts/DoubleIndexedCommandContext.hpp"
 
-class SwapCommandContext : public CommandContext {
+class SwapCommandContext : public DoubleIndexedCommandContext {
 public:
-    ConstRepository repository;
-    int index1;
-    int index2;
-
-    /**
-    * @brief Constructs a context for a "swap" command operation.
-    *
-    * This constructor initializes the context with a constant reference to the repository
-    * and the two indexes of the sets to be swapped.
-    *
-    * @param repository The constant reference to the repository containing the sets.
-    * @param index1 The index of the first set to be swapped.
-    * @param index2 The index of the second set to be swapped.
-    */
-    SwapCommandContext(ConstRepository repository, int index1, int index2);
+  /**
+   * @brief Constructs a context for a "swap" command operation.
+   *
+   * This constructor initializes the context with a constant reference to the
+   * repository and the two indexes of the sets to be swapped.
+   *
+   * @param repository The constant reference to the repository containing the
+   * sets.
+   * @param index1 The index of the first set to be swapped.
+   * @param index2 The index of the second set to be swapped.
+   */
+  SwapCommandContext(ConstRepository repository, int index1, int index2);
 };
 
 #endif

--- a/include/Commander/Contexts/UnionCommandContext.hpp
+++ b/include/Commander/Contexts/UnionCommandContext.hpp
@@ -1,0 +1,20 @@
+#ifndef UNION_CONTEXT_COMMAND_HPP
+#define UNION_CONTEXT_COMMAND_HPP
+
+#include <string>
+
+#include "Commander/Contexts/DoubleIndexedCommandContext.hpp"
+
+using std::string;
+
+class UnionCommandContext : public DoubleIndexedCommandContext {
+public:
+  /**
+   * @brief Context builder to join two sets on the system
+   *
+   * @param repository DI for data from the running system
+   */
+  UnionCommandContext(ConstRepository repository, int index1, int index2);
+};
+
+#endif

--- a/include/Commander/Contexts/UnionCommandContext.hpp
+++ b/include/Commander/Contexts/UnionCommandContext.hpp
@@ -7,14 +7,14 @@
 
 using std::string;
 
-class UnionCommandContext : public DoubleIndexedCommandContext {
+class UnionCommandContext : public DoubleIndexedCommandContext<Repository> {
 public:
   /**
    * @brief Context builder to join two sets on the system
    *
    * @param repository DI for data from the running system
    */
-  UnionCommandContext(ConstRepository repository, int index1, int index2);
+  UnionCommandContext(Repository repository, int index1, int index2);
 };
 
 #endif

--- a/include/Commander/Contexts/UnionCommandContext.hpp
+++ b/include/Commander/Contexts/UnionCommandContext.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "../def/Repository.hpp"
 #include "Commander/Contexts/DoubleIndexedCommandContext.hpp"
 
 using std::string;

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -202,6 +202,31 @@ private:
    */
   Node *search(int key, Node *node) const;
 
+  /**
+   * @brief Inserts all keys from the given subtree into another set.
+   *
+   * This function performs an in-order traversal of the subtree rooted at `T`,
+   * inserting each node’s key into the target set `U`, preserving sorted order.
+   *
+   * @param T Pointer to the root of the subtree whose keys will be inserted.
+   * @param U Reference to the set into which keys from the subtree will be
+   * inserted.
+   */
+  void insertSubtree(const Set &T, Set &U) const;
+
+  /**
+   * @brief Creates the union of two subtrees into the target set.
+   *
+   * This function traverses both input subtrees in parallel, inserting all keys
+   * from both trees into the target set `U`. It handles cases where one subtree
+   * is null by inserting all remaining keys from the other subtree.
+   *
+   * @param t1 Pointer to the root of the first subtree.
+   * @param t2 Pointer to the root of the second subtree.
+   * @param U Reference to the set where the union of keys will be stored.
+   */
+  void unionSet(const Set &t1, const Set &t2, Set &U) const;
+
 public:
   /**
    * @brief Set builder
@@ -349,19 +374,34 @@ public:
   int predecessor(int key) const;
 
   /**
-  * @brief Returns the key of the successor for the given key in the set.
-  *
-  * This function searches for the node with the specified key, then finds the smallest key
-  * greater than the given key. It first checks if the set is empty and throws an exception if so.
-  * If the key is not found or no successor exists, appropriate exceptions are thrown.
-  *
-  * @param key The key whose successor is to be found.
-  * @return int The key of the successor node.
-  * @throws EmptySetException if the set is empty.
-  * @throws ValueNotFoundException if the specified key is not found in the set.
-  * @throws NoSuccessorException if there is no successor for the given key.
-  */
+   * @brief Returns the key of the successor for the given key in the set.
+   *
+   * This function searches for the node with the specified key, then finds the
+   * smallest key greater than the given key. It first checks if the set is
+   * empty and throws an exception if so. If the key is not found or no
+   * successor exists, appropriate exceptions are thrown.
+   *
+   * @param key The key whose successor is to be found.
+   * @return int The key of the successor node.
+   * @throws EmptySetException if the set is empty.
+   * @throws ValueNotFoundException if the specified key is not found in the
+   * set.
+   * @throws NoSuccessorException if there is no successor for the given key.
+   */
   int successor(int key) const;
+
+  /**
+   * @brief Returns a new set representing the union of this set and another.
+   *
+   * This function creates a temporary set `U`, inserts all elements from
+   * both the current set and the given set `T` into it, and returns `U` as
+   * the union of the two sets.
+   *
+   * @param T The set to union with the current set.
+   * @return Set A new set containing all unique elements from both sets.
+   */
+  void unionSet(const Set &set) const;
+
 #ifdef TEST_MODE
   // Retorna a raiz da árvore (para fins de teste)
   Node *getRoot() const;

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -397,7 +397,7 @@ public:
    * both the current set and the given set `T` into it, and returns `U` as
    * the union of the two sets.
    *
-   * @param T The set to union with the current set.
+   * @param set The set to union with the current set.
    * @return Set A new set containing all unique elements from both sets.
    */
   Set unionSet(const Set &set) const;

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -400,7 +400,7 @@ public:
    * @param set The set to union with the current set.
    * @return Set A new set containing all unique elements from both sets.
    */
-  Set unionSet(const Set &set) const;
+  Set* unionSet(const Set &T) const;
 
 #ifdef TEST_MODE
   // Retorna a raiz da árvore (para fins de teste)

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -212,7 +212,7 @@ private:
    * @param U Reference to the set into which keys from the subtree will be
    * inserted.
    */
-  void insertSubtree(const Set &T, Set &U) const;
+  void insertSubtree(Node *T, Set &U) const;
 
   /**
    * @brief Creates the union of two subtrees into the target set.
@@ -225,7 +225,7 @@ private:
    * @param t2 Pointer to the root of the second subtree.
    * @param U Reference to the set where the union of keys will be stored.
    */
-  void unionSet(const Set &t1, const Set &t2, Set &U) const;
+  void unionSet(Node *t1, Node *t2, Set &U) const;
 
 public:
   /**
@@ -400,7 +400,7 @@ public:
    * @param T The set to union with the current set.
    * @return Set A new set containing all unique elements from both sets.
    */
-  void unionSet(const Set &set) const;
+  Set unionSet(const Set &set) const;
 
 #ifdef TEST_MODE
   // Retorna a raiz da árvore (para fins de teste)

--- a/include/Utils/Tools/FormatOrigin.hpp
+++ b/include/Utils/Tools/FormatOrigin.hpp
@@ -1,0 +1,11 @@
+#ifndef FORMAT_ORIGIN_HPP
+#define FORMAT_ORIGIN_HPP
+
+#include <string>
+
+using std::string;
+using std::to_string;
+
+string formatOrigin(string op, int index1, int index2);
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,7 @@
 #include "Commander/Commands/ShowCommand.hpp"
 #include "Commander/Commands/SizeCommand.hpp"
 #include "Commander/Commands/SwapCommand.hpp"
+#include "Commander/Commands/UnionCommand.hpp"
 #include "Commander/Invoker/CommandInvoker.hpp"
 
 #include "Utils/Validation/ValidateOnlyIntegers.hpp"
@@ -68,6 +69,7 @@ int main() {
   PredecessorCommand predecessorCommand(
       "predecessor", "exibe o antecessor de um dado numero de um conjunto");
   SuccessorCommand successorCommand("successor", "exibe o sucessor de um dado numero de um conjunto");
+  UnionCommand unionCommand("union", "une dois conjuntos do sistema");
 
   invoker.registerCommand(
       createCommand.getName(), &createCommand, [&sets]() -> CommandContext * {
@@ -200,6 +202,15 @@ int main() {
 
   	return new SuccessorCommandContext(sets, index, key);
   });  
+
+  invoker.registerCommand(unionCommand.getName(), &unionCommand,  [&sets]() -> CommandContext * {
+  	ValidateRepositoryNotEmpty(sets);
+
+  	int index1 = promptValidIndex(sets, PromptIndexFirstSet),
+  	    index2 = promptValidIndex(sets, PromptIndexSecondSet);
+
+  	return new UnionCommandContext(sets, index1, index2);
+  });
 
   while (true) {
     try {

--- a/src/Commander/Commands/UnionCommand.cpp
+++ b/src/Commander/Commands/UnionCommand.cpp
@@ -1,19 +1,20 @@
 #include "Commander/Commands/UnionCommand.hpp"
 
-UnionCommand::UnionCommand(const string& name, const string& description)
+UnionCommand::UnionCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void UnionCommand::execute(CommandContext *context) const {
-    auto *ctx = dynamic_cast<UnionCommandContext *>(context);
-    
-    if (ctx) {
-        Repository repo = ctx->repository;
-        int index1 = ctx->index1, index2 = ctx->index2;
-        
-        Set res = repo[index1].set->unionSet(*(repo[index2].set));
+  auto *ctx = dynamic_cast<UnionCommandContext *>(context);
 
-        repo.emplace_back(&res, formatOrigin("uniao", index1, index2));
-        
-        cout << "A uniao dos conjuntos foi armazenada em " << (repo.size() - 1) <<  '\n';
-    }
-}   
+  if (ctx) {
+    Repository repo = ctx->repository;
+    int index1 = ctx->index1, index2 = ctx->index2;
+
+    Set *res = repo[index1].set->unionSet(*(repo[index2].set));
+
+    repo.emplace_back(res, formatOrigin("uniao", index1, index2));
+
+    cout << "A uniao dos conjuntos foi armazenada em " << (repo.size() - 1)
+         << '\n';
+  }
+}

--- a/src/Commander/Commands/UnionCommand.cpp
+++ b/src/Commander/Commands/UnionCommand.cpp
@@ -1,0 +1,19 @@
+#include "Commander/Commands/UnionCommand.hpp"
+
+UnionCommand::UnionCommand(const string& name, const string& description)
+    : Command(name, description) {}
+
+void UnionCommand::execute(CommandContext *context) const {
+    auto *ctx = dynamic_cast<UnionCommandContext *>(context);
+    
+    if (ctx) {
+        Repository repo = ctx->repository;
+        int index1 = ctx->index1, index2 = ctx->index2;
+        
+        Set res = repo[index1].set->unionSet(*(repo[index2].set));
+
+        repo.emplace_back(res, formatOrigin("uniao", index1, index2));
+        
+        cout << "A uniao dos conjuntos foi armazenada em " << repo[repo.size() - 1]  <<  '\n';
+    }
+}   

--- a/src/Commander/Commands/UnionCommand.cpp
+++ b/src/Commander/Commands/UnionCommand.cpp
@@ -12,8 +12,8 @@ void UnionCommand::execute(CommandContext *context) const {
         
         Set res = repo[index1].set->unionSet(*(repo[index2].set));
 
-        repo.emplace_back(res, formatOrigin("uniao", index1, index2));
+        repo.emplace_back(&res, formatOrigin("uniao", index1, index2));
         
-        cout << "A uniao dos conjuntos foi armazenada em " << repo[repo.size() - 1]  <<  '\n';
+        cout << "A uniao dos conjuntos foi armazenada em " << (repo.size() - 1) <<  '\n';
     }
 }   

--- a/src/Commander/Contexts/SwapCommandContext.cpp
+++ b/src/Commander/Contexts/SwapCommandContext.cpp
@@ -1,4 +1,5 @@
 #include "Commander/Contexts/SwapCommandContext.hpp"
 
-SwapCommandContext::SwapCommandContext(ConstRepository repository, int index1, int index2)
-    : repository(repository), index1(index1), index2(index2) {}
+SwapCommandContext::SwapCommandContext(ConstRepository repository, int index1,
+                                       int index2)
+    : DoubleIndexedCommandContext(repository, index1, index2) {}

--- a/src/Commander/Contexts/UnionCommandContext.cpp
+++ b/src/Commander/Contexts/UnionCommandContext.cpp
@@ -1,0 +1,5 @@
+#include "Commander/Contexts/UnionCommandContext.hpp"
+
+UnionCommandContext::UnionCommandContext(ConstRepository repository, int index1,
+                                         int index2)
+    : DoubleIndexedCommandContext(repository, index1, index2) {}

--- a/src/Commander/Contexts/UnionCommandContext.cpp
+++ b/src/Commander/Contexts/UnionCommandContext.cpp
@@ -1,5 +1,5 @@
 #include "Commander/Contexts/UnionCommandContext.hpp"
 
-UnionCommandContext::UnionCommandContext(ConstRepository repository, int index1,
+UnionCommandContext::UnionCommandContext(Repository repository, int index1,
                                          int index2)
     : DoubleIndexedCommandContext(repository, index1, index2) {}

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -326,7 +326,7 @@ int Set::successor(int key) const {
 	return successor->key;	
 }
 
-void Set::unionSet(const Set& T) const {
+Set Set::unionSet(const Set& T) const {
 	Set U;
 	unionSet(root, T.root, U);
 	return U;

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -326,9 +326,9 @@ int Set::successor(int key) const {
 	return successor->key;	
 }
 
-Set Set::unionSet(const Set& T) const {
-	Set U;
-	unionSet(root, T.root, U);
+Set* Set::unionSet(const Set& T) const {
+	Set *U = new Set();
+	unionSet(root, T.root, *U);
 	return U;
 }
 

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -182,6 +182,37 @@ Node* Set::search(int key, Node *node) const {
   }
 }
 
+void Set::insertSubtree(Node* T, Set& U) const {
+	if (!T) return;
+
+	insertSubtree(T->left, U);
+
+	U.insert(T->key);
+	
+	insertSubtree(T->right, U);
+}
+
+void Set::unionSet(Node* t1, Node* t2, Set& U) const {
+	if (!t1 and !t2) return;
+	
+	if (!t1) {
+		insertSubtree(t2, U);
+		return;
+	}
+	
+	if (!t2) {
+		insertSubtree(t1, U);
+		return;
+	}
+
+	unionSet(t1->left, t2->left, U);
+
+	U.insert(t1->key);
+	U.insert(t2->key);
+
+	unionSet(t1->right, t2->right, U);
+}
+
 /**
  * Public Functions
  */
@@ -293,6 +324,12 @@ int Set::successor(int key) const {
 		throw NoSuccessorException(NoSuccessorMessage(key));
 
 	return successor->key;	
+}
+
+void Set::unionSet(const Set& T) const {
+	Set U;
+	unionSet(root, T.root, U);
+	return U;
 }
 
 #ifdef TEST_MODE

--- a/src/Utils/Tools/FormatOrigin.cpp
+++ b/src/Utils/Tools/FormatOrigin.cpp
@@ -2,5 +2,5 @@
 
 string formatOrigin(string op, int index1, int index2) {
   string idx1 = to_string(index1), idx2 = to_string(index2);
-  return "fomado pela " + op + " entre os conjuntos " + idx1 + " e " + idx2;
+  return "formado pela " + op + " entre os conjuntos " + idx1 + " e " + idx2;
 }

--- a/src/Utils/Tools/FormatOrigin.cpp
+++ b/src/Utils/Tools/FormatOrigin.cpp
@@ -1,0 +1,6 @@
+#include "Utils/Tools/FormatOrigin.hpp"
+
+string formatOrigin(string op, int index1, int index2) {
+	string idx1 = to_string(index1), idx2 = to_string(index2);
+	return "fomado pela " + op + " entre os conjuntos " + idx1 " e " + idx2;
+}

--- a/src/Utils/Tools/FormatOrigin.cpp
+++ b/src/Utils/Tools/FormatOrigin.cpp
@@ -1,6 +1,6 @@
 #include "Utils/Tools/FormatOrigin.hpp"
 
 string formatOrigin(string op, int index1, int index2) {
-	string idx1 = to_string(index1), idx2 = to_string(index2);
-	return "fomado pela " + op + " entre os conjuntos " + idx1 " e " + idx2;
+  string idx1 = to_string(index1), idx2 = to_string(index2);
+  return "fomado pela " + op + " entre os conjuntos " + idx1 + " e " + idx2;
 }


### PR DESCRIPTION
This pull request introduces the `UnionCommand` feature, which allows users to create a union of two sets in the system. It includes the implementation of the `UnionCommand`, its context, supporting utilities, and modifications to the `Set` class to enable union operations. Additionally, it refactors the `SwapCommandContext` to reuse a generic context class for indexed commands.

### New Feature: Union Command

* **`include/Commander/Commands/UnionCommand.hpp`**: Added the `UnionCommand` class, which inherits from `Command` and performs union operations between two sets.
* **`src/Commander/Commands/UnionCommand.cpp`**: Implemented the `UnionCommand::execute` method to compute the union of two sets and store the result in the repository.
* **`main.cpp`**: Registered the `UnionCommand` in the `CommandInvoker` and added user input handling for selecting sets to union. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR33) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR72) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR206-R214)

### Context Handling Improvements

* **`include/Commander/Contexts/UnionCommandContext.hpp`**: Introduced the `UnionCommandContext` class, which extends `DoubleIndexedCommandContext` to provide context for union operations.
* **`src/Commander/Contexts/UnionCommandContext.cpp`**: Implemented the constructor for `UnionCommandContext` to initialize repository and indices.
* **`include/Commander/Contexts/DoubleIndexedCommandContext.hpp`**: Added a generic `DoubleIndexedCommandContext` template class to handle contexts with two indices and a repository, enabling reuse across commands.
* **`src/Commander/Contexts/SwapCommandContext.cpp`**: Refactored `SwapCommandContext` to inherit from `DoubleIndexedCommandContext`, reducing redundancy.

### Enhancements to the `Set` Class

* **`include/Set/Set.hpp` and `src/Set/Set.cpp`**: Added methods `insertSubtree`, `unionSet(Node*, Node*, Set&)`, and `unionSet(const Set&)` to support union operations between sets. These methods handle merging two binary search trees into a new set. [[1]](diffhunk://#diff-9d36b5a7d015fe5a3d87ad5ef59367a99bbe53c647d6fcb1e9704ccf2d136dbfR205-R229) [[2]](diffhunk://#diff-9d36b5a7d015fe5a3d87ad5ef59367a99bbe53c647d6fcb1e9704ccf2d136dbfL354-R404) [[3]](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8R185-R215) [[4]](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8R329-R334)

### Utility Additions

* **`include/Utils/Tools/FormatOrigin.hpp` and `src/Utils/Tools/FormatOrigin.cpp`**: Introduced the `formatOrigin` function to format a descriptive string for the origin of a new set created by a union operation. [[1]](diffhunk://#diff-bd2064ba9db33cfff332ada21a0e311c7bebf95767a44424cec7ef13aa9d33f2R1-R11) [[2]](diffhunk://#diff-d828c7549a3f41938bf2e4c4fa415b05f318e7370786deafef55dcf0094d9c7cR1-R6)