### PR TITLE
(feat): binary tree traversal algorithm

### DIFF
--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -227,6 +227,18 @@ private:
    */
   void unionSet(Node *t1, Node *t2, Set &U) const;
 
+  /**
+   * @brief Returns a new set representing the union of this set and another.
+   *
+   * This function creates a temporary set `U`, inserts all elements from
+   * both the current set and the given set `T` into it, and returns `U` as
+   * the union of the two sets.
+   *
+   * @param T The set to union with the current set.
+   * @return Set A new set containing all unique elements from both sets.
+   */
+  void inOrder(Node *node, vector<int> &v) const;
+
 public:
   /**
    * @brief Set builder
@@ -400,7 +412,18 @@ public:
    * @param set The set to union with the current set.
    * @return Set A new set containing all unique elements from both sets.
    */
-  Set* unionSet(const Set &T) const;
+  Set *unionSet(const Set &T) const;
+
+  /**
+   * @brief Returns a vector of all keys in the set using in-order traversal.
+   *
+   * This function allocates a vector with reserved space equal to the set size,
+   * performs an in-order traversal starting from the root to collect keys in
+   * sorted order, and returns the filled vector.
+   *
+   * @return std::vector<int> A vector containing all keys in ascending order.
+   */
+  vector<int> inOrder() const;
 
 #ifdef TEST_MODE
   // Retorna a raiz da árvore (para fins de teste)

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -169,7 +169,7 @@ Node *Set::getMax(Node *node) const {
   return getMax(node->right);
 }
 
-Node* Set::search(int key, Node *node) const {
+Node *Set::search(int key, Node *node) const {
   if (!node)
     return nullptr;
 
@@ -182,35 +182,48 @@ Node* Set::search(int key, Node *node) const {
   }
 }
 
-void Set::insertSubtree(Node* T, Set& U) const {
-	if (!T) return;
+void Set::insertSubtree(Node *T, Set &U) const {
+  if (!T)
+    return;
 
-	insertSubtree(T->left, U);
+  insertSubtree(T->left, U);
 
-	U.insert(T->key);
-	
-	insertSubtree(T->right, U);
+  U.insert(T->key);
+
+  insertSubtree(T->right, U);
 }
 
-void Set::unionSet(Node* t1, Node* t2, Set& U) const {
-	if (!t1 and !t2) return;
-	
-	if (!t1) {
-		insertSubtree(t2, U);
-		return;
-	}
-	
-	if (!t2) {
-		insertSubtree(t1, U);
-		return;
-	}
+void Set::unionSet(Node *t1, Node *t2, Set &U) const {
+  if (!t1 and !t2)
+    return;
 
-	unionSet(t1->left, t2->left, U);
+  if (!t1) {
+    insertSubtree(t2, U);
+    return;
+  }
 
-	U.insert(t1->key);
-	U.insert(t2->key);
+  if (!t2) {
+    insertSubtree(t1, U);
+    return;
+  }
 
-	unionSet(t1->right, t2->right, U);
+  unionSet(t1->left, t2->left, U);
+
+  U.insert(t1->key);
+  U.insert(t2->key);
+
+  unionSet(t1->right, t2->right, U);
+}
+
+void inOrder(Node *node, vector<int> &v) const {
+  if (!node)
+    return;
+
+  inOrder(node->left, v, size);
+
+  v.push_back(node->key);
+
+  inOrder(node->right, v, size);
 }
 
 /**
@@ -297,39 +310,48 @@ int Set::predecessor(int key) const {
 }
 
 int Set::successor(int key) const {
-	if (empty())
-		throw EmptySetException(EmptySetMessage());
+  if (empty())
+    throw EmptySetException(EmptySetMessage());
 
-	Node* node = search(key, root);
+  Node *node = search(key, root);
 
-	if (!node)
-		throw ValueNotFoundException(ValueNotFoundMessage(key));
+  if (!node)
+    throw ValueNotFoundException(ValueNotFoundMessage(key));
 
-	if (node->right)
-		return getMin(node->right)->key;
+  if (node->right)
+    return getMin(node->right)->key;
 
-	Node* aux = root, *successor = nullptr;
-	while (aux) {
-		if (node->key < aux->key) {
-			successor = aux;
-			aux = aux->left;
-		} else if (node->key > aux->key) {
-			aux = aux->right;
-		} else {
-			break;
-		}
-	}
+  Node *aux = root, *successor = nullptr;
+  while (aux) {
+    if (node->key < aux->key) {
+      successor = aux;
+      aux = aux->left;
+    } else if (node->key > aux->key) {
+      aux = aux->right;
+    } else {
+      break;
+    }
+  }
 
-	if (!successor)
-		throw NoSuccessorException(NoSuccessorMessage(key));
+  if (!successor)
+    throw NoSuccessorException(NoSuccessorMessage(key));
 
-	return successor->key;	
+  return successor->key;
 }
 
-Set* Set::unionSet(const Set& T) const {
-	Set *U = new Set();
-	unionSet(root, T.root, *U);
-	return U;
+vector<int> inOrder() const {
+  vector<int> v;
+  v.reserve(_size);
+
+  inOrder(root, v);
+
+  return v;
+}
+
+Set *Set::unionSet(const Set &T) const {
+  Set *U = new Set();
+  unionSet(root, T.root, *U);
+  return U;
 }
 
 #ifdef TEST_MODE

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -215,7 +215,7 @@ void Set::unionSet(Node *t1, Node *t2, Set &U) const {
   unionSet(t1->right, t2->right, U);
 }
 
-void inOrder(Node *node, vector<int> &v) const {
+void Set::inOrder(Node *node, vector<int> &v) const {
   if (!node)
     return;
 

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -219,11 +219,11 @@ void inOrder(Node *node, vector<int> &v) const {
   if (!node)
     return;
 
-  inOrder(node->left, v, size);
+  inOrder(node->left, v);
 
   v.push_back(node->key);
 
-  inOrder(node->right, v, size);
+  inOrder(node->right, v);
 }
 
 /**


### PR DESCRIPTION
This pull request introduces new functionality for in-order traversal in the `Set` class, along with minor code style adjustments for readability. The most significant changes include adding methods for in-order traversal and improving code consistency.

### New functionality:

* **In-order traversal helper function**: Added a private method `inOrder(Node *node, vector<int> &v) const` to perform in-order traversal and collect keys into a vector. This method is recursive and processes the left subtree, the current node, and the right subtree in order. (`src/Set/Set.cpp`, [src/Set/Set.cppR218-R228](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8R218-R228))
* **Public in-order traversal method**: Added a public method `vector<int> inOrder() const` that returns a vector of all keys in the set in ascending order. This method reserves space for the vector based on the set size and uses the private helper method to populate it. (`include/Set/Set.hpp`, [[1]](diffhunk://#diff-9d36b5a7d015fe5a3d87ad5ef59367a99bbe53c647d6fcb1e9704ccf2d136dbfR417-R427); `src/Set/Set.cpp`, [[2]](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8R342-R350)

### Code style improvements:

* **Formatting adjustments**: Updated conditional statements in `Set::insertSubtree` and `Set::unionSet` methods to improve readability by ensuring consistent indentation and spacing. (`src/Set/Set.cpp`, [[1]](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8L186-R187) [[2]](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8L196-R198)