### PR TITLE
Feat/difference

### DIFF
--- a/include/Commander/Commands/DifferenceCommand.hpp
+++ b/include/Commander/Commands/DifferenceCommand.hpp
@@ -1,0 +1,29 @@
+#ifndef DIFFERENCE_COMMAND_HPP
+#define DIFFERENCE_COMMAND_HPP
+
+#include <iostream>
+
+#include "Commander/Commands/Command.hpp"
+#include "Commander/Contexts/DifferenceCommandContext.hpp"
+#include "Utils/Tools/FormatOrigin.hpp"
+
+using std::cout;
+
+class DifferenceCommand : public Command {
+public:
+  /**
+   * @brief Constructs a DifferenceCommand with the given name and
+   * description.
+   *
+   * Initializes the base Command class using the provided name and description,
+   * setting up the command to perform a union operation between two sets.
+   *
+   * @param name The name of the command.
+   * @param description A brief description of what the command does.
+   */
+  DifferenceCommand(const string &name, const string &description);
+
+  void execute(CommandContext *context) const override;
+};
+
+#endif

--- a/include/Commander/Commands/ListCommand.hpp
+++ b/include/Commander/Commands/ListCommand.hpp
@@ -1,0 +1,28 @@
+#ifndef LIST_COMMAND_HPP
+#define LIST_COMMAND_HPP
+
+#include <iostream>
+#include <string>
+
+using std::cout;
+using std::string;
+
+#include "Commander/Commands/Command.hpp"
+#include "Commander/Contexts/ListCommandContext.hpp"
+
+class ListCommand : public Command {
+public:
+  /*
+   * @brief ListCommand constructor
+   */
+  ListCommand(const string &name, const string &description);
+
+  /*
+   * @brief ListCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
+};
+
+#endif

--- a/include/Commander/Contexts/DifferenceCommandContext.hpp
+++ b/include/Commander/Contexts/DifferenceCommandContext.hpp
@@ -1,0 +1,22 @@
+#ifndef DIFFERENCE_CONTEXT_COMMAND_HPP
+#define DIFFERENCE_CONTEXT_COMMAND_HPP
+
+#include <string>
+
+#include "../def/Repository.hpp"
+#include "Commander/Contexts/DoubleIndexedCommandContext.hpp"
+
+using std::string;
+
+class DifferenceCommandContext
+    : public DoubleIndexedCommandContext<Repository> {
+public:
+  /**
+   * @brief Context builder to diff two sets on the system
+   *
+   * @param repository DI for data from the running system
+   */
+  DifferenceCommandContext(Repository repository, int index1, int index2);
+};
+
+#endif

--- a/include/Commander/Contexts/ListCommandContext.hpp
+++ b/include/Commander/Contexts/ListCommandContext.hpp
@@ -1,0 +1,19 @@
+#ifndef LIST_CONTEXT_COMMAND_HPP
+#define LIST_CONTEXT_COMMAND_HPP
+
+#include "../def/ConstRepository.hpp"
+#include "Commander/Contexts/CommandContext.hpp"
+
+class ListCommandContext : public CommandContext {
+public:
+  ConstRepository repository;
+
+  /**
+   * @brief Context builder to List command
+   *
+   * @param repository DI for data from the running system
+   */
+  ListCommandContext(ConstRepository repository);
+};
+
+#endif

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -440,6 +440,7 @@ public:
    */
   Set *intersectionSet(const Set &T) const;
 
+  Set *differenceSet(const Set &T) const;
 #ifdef TEST_MODE
   // Retorna a raiz da árvore (para fins de teste)
   Node *getRoot() const;

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,7 @@
 #include "Commander/Commands/EraseCommand.hpp"
 #include "Commander/Commands/InsertCommand.hpp"
 #include "Commander/Commands/IntersectionCommand.hpp"
+#include "Commander/Commands/ListCommand.hpp"
 #include "Commander/Commands/MaximumCommand.hpp"
 #include "Commander/Commands/MinimumCommand.hpp"
 #include "Commander/Commands/PredecessorCommand.hpp"
@@ -78,6 +79,8 @@ int main() {
   DifferenceCommand differenceCommand(
       "difference", "extrai todos os elementos exclusivos do primeiro em "
                     "relacao a uniao de dois conjuntos no sistema");
+  ListCommand listCommand("list",
+                          "lista a origem de todos os conjuntos do sistema");
 
   invoker.registerCommand(
       createCommand.getName(), &createCommand, [&sets]() -> CommandContext * {
@@ -245,6 +248,13 @@ int main() {
 
         return new DifferenceCommandContext(sets, index1, index2);
       });
+
+  invoker.registerCommand(listCommand.getName(), &listCommand,
+                          [&sets]() -> CommandContext * {
+                            ValidateRepositoryNotEmpty(sets);
+
+                            return new ListCommandContext(sets);
+                          });
 
   while (true) {
     try {

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,7 @@
 #include "Commander/Commands/ClearCommand.hpp"
 #include "Commander/Commands/ContainsCommand.hpp"
 #include "Commander/Commands/CreateCommand.hpp"
+#include "Commander/Commands/DifferenceCommand.hpp"
 #include "Commander/Commands/EmptyCommand.hpp"
 #include "Commander/Commands/EraseCommand.hpp"
 #include "Commander/Commands/InsertCommand.hpp"
@@ -74,6 +75,9 @@ int main() {
   UnionCommand unionCommand("union", "une dois conjuntos do sistema");
   IntersectionCommand intersectionCommand(
       "intersecao", "reune os elementos em comum de dois conjuntos do sistema");
+  DifferenceCommand differenceCommand(
+      "difference", "extrai todos os elementos exclusivos do primeiro em "
+                    "relacao a uniao de dois conjuntos no sistema");
 
   invoker.registerCommand(
       createCommand.getName(), &createCommand, [&sets]() -> CommandContext * {
@@ -229,6 +233,17 @@ int main() {
             index2 = promptValidIndex(sets, PromptIndexSecondSet);
 
         return new IntersectionCommandContext(sets, index1, index2);
+      });
+
+  invoker.registerCommand(
+      differenceCommand.getName(), &differenceCommand,
+      [&sets]() -> CommandContext * {
+        ValidateRepositoryNotEmpty(sets);
+
+        int index1 = promptValidIndex(sets, PromptIndexFirstSet),
+            index2 = promptValidIndex(sets, PromptIndexSecondSet);
+
+        return new DifferenceCommandContext(sets, index1, index2);
       });
 
   while (true) {

--- a/src/Commander/Commands/DifferenceCommand.cpp
+++ b/src/Commander/Commands/DifferenceCommand.cpp
@@ -1,0 +1,21 @@
+#include "Commander/Commands/DifferenceCommand.hpp"
+
+DifferenceCommand::DifferenceCommand(const string &name,
+                                     const string &description)
+    : Command(name, description) {}
+
+void DifferenceCommand::execute(CommandContext *context) const {
+  auto *ctx = dynamic_cast<DifferenceCommandContext *>(context);
+
+  if (ctx) {
+    Repository repo = ctx->repository;
+    int index1 = ctx->index1, index2 = ctx->index2;
+
+    Set *res = repo[index1].set->differenceSet(*(repo[index2].set));
+
+    repo.emplace_back(res, formatOrigin("diferenca", index1, index2));
+
+    cout << "A diferenca dos conjuntos foi armazenada em " << (repo.size() - 1)
+         << '\n';
+  }
+}

--- a/src/Commander/Commands/ListCommand.cpp
+++ b/src/Commander/Commands/ListCommand.cpp
@@ -1,0 +1,15 @@
+#include "Commander/Commands/ListCommand.hpp"
+
+ListCommand::ListCommand(const string &name, const string &description)
+    : Command(name, description) {}
+
+void ListCommand::execute(CommandContext *context) const {
+  auto *ctx = dynamic_cast<ListCommandContext *>(context);
+
+  if (ctx) {
+    ConstRepository repo = ctx->repository;
+
+    for (size_t i = 0; i < repo.size(); i++)
+      cout << "Conjunto " << i << " - " << repo[i].origin << '\n';
+  }
+}

--- a/src/Commander/Contexts/DifferenceCommandContext.cpp
+++ b/src/Commander/Contexts/DifferenceCommandContext.cpp
@@ -1,0 +1,5 @@
+#include "Commander/Contexts/DifferenceCommandContext.hpp"
+
+DifferenceCommandContext::DifferenceCommandContext(Repository repository,
+                                                   int index1, int index2)
+    : DoubleIndexedCommandContext(repository, index1, index2) {}

--- a/src/Commander/Contexts/ListCommandContext.cpp
+++ b/src/Commander/Contexts/ListCommandContext.cpp
@@ -1,0 +1,4 @@
+#include "Commander/Contexts/ListCommandContext.hpp"
+
+ListCommandContext::ListCommandContext(ConstRepository repository)
+    : repository(repository) {}

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -373,7 +373,7 @@ Set *Set::differenceSet(const Set &T) const {
   int i = 0, j = 0;
   Set *D = new Set();
 
-  while (i < _size and j < T.size()) {
+  while (i < v1.size() and j < v2.size()) {
     if (v1[i] == v2[j]) {
       i++;
       j++;

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -107,22 +107,6 @@ bool Set::contains(int key, Node *node) const {
     return contains(key, node->right);
 }
 
-void Set::show(Node *node, string inheritance) const {
-  if (node != nullptr && (node->left != nullptr || node->right != nullptr))
-    show(node->right, inheritance + "r");
-  for (int i = 0; i < (int)inheritance.size() - 1; i++)
-    cout << (inheritance[i] != inheritance[i + 1] ? "│   " : "    ");
-  if (inheritance != "")
-    cout << (inheritance.back() == 'r' ? "┌───" : "└───");
-  if (node == nullptr) {
-    cout << "#" << endl;
-    return;
-  }
-  cout << node->key << endl;
-  if (node != nullptr && (node->left != nullptr || node->right != nullptr))
-    show(node->left, inheritance + "l");
-}
-
 Node *Set::erase(int key, Node *node) {
   if (!node)
     return nullptr;
@@ -256,7 +240,14 @@ bool Set::empty() const { return _size == 0 and !root; }
 
 int Set::size() const { return _size; }
 
-void Set::show() const { show(root, ""); }
+void Set::show() const {
+  vector<int> v = inOrder();
+
+  cout << "[ ";
+  for (int e : v)
+    cout << e << " ";
+  cout << "]\n";
+}
 
 void Set::clear() {
   clear(root);

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -376,6 +376,30 @@ Set *Set::intersectionSet(const Set &T) const {
   return I;
 }
 
+Set *Set::differenceSet(const Set &set) const {
+  vector<int> v1 = this->inOrder(), v2 = T.inOrder();
+
+  int i = 0, j = 0;
+  Set *D = new Set();
+
+  while (i < _size and j < T.size()) {
+    if (v1[i] == v2[j]) {
+      i++;
+      j++;
+    } else if (v1[i] < v2[j]) {
+      D.insert(v1[i]);
+      i++;
+    } else {
+      j++;
+    }
+  }
+
+  while (i < _size)
+    D.insert(v1[i]);
+
+  return D;
+}
+
 #ifdef TEST_MODE
 Node *Set::getRoot() const { return root; }
 int Set::getBalanceForTest(Node *node) const { return getBalance(node); }

--- a/src/Set/Set.cpp
+++ b/src/Set/Set.cpp
@@ -376,7 +376,7 @@ Set *Set::intersectionSet(const Set &T) const {
   return I;
 }
 
-Set *Set::differenceSet(const Set &set) const {
+Set *Set::differenceSet(const Set &T) const {
   vector<int> v1 = this->inOrder(), v2 = T.inOrder();
 
   int i = 0, j = 0;
@@ -387,15 +387,17 @@ Set *Set::differenceSet(const Set &set) const {
       i++;
       j++;
     } else if (v1[i] < v2[j]) {
-      D.insert(v1[i]);
+      D->insert(v1[i]);
       i++;
     } else {
       j++;
     }
   }
 
-  while (i < _size)
-    D.insert(v1[i]);
+  while (i < _size) {
+    D->insert(v1[i]);
+    i++;
+  }
 
   return D;
 }


### PR DESCRIPTION
This pull request introduces two new commands, `DifferenceCommand` and `ListCommand`, to the system, along with their respective contexts. It also includes enhancements to the `Set` class and some refactoring of existing code. Below is a breakdown of the most important changes:

### New Commands and Contexts

* Added `DifferenceCommand` to compute the difference between two sets and store the result in the repository. This includes the addition of the `DifferenceCommand` class, its `execute` method, and its context, `DifferenceCommandContext`. [[1]](diffhunk://#diff-80e88c73a708ee47a092eab4ea706ad05f676c0e2ab153a1bfc9a1ea1462c8a3R1-R29) [[2]](diffhunk://#diff-cfc6dd3b185b97d4f0726ef573cd50f2aa6ff91f664e98fefeeb5558c36604c0R1-R21) [[3]](diffhunk://#diff-9708ab9bf5e7e6077469b8e6033de96bd9ab031ce77ecddfc411f0d5d5f29c48R1-R22) [[4]](diffhunk://#diff-5f68d365434997eccdfa5fac8ba2b2c961fc38ca0abab155b2b90ed6a779cc0bR1-R5)
* Added `ListCommand` to list the origins of all sets in the repository. This includes the addition of the `ListCommand` class, its `execute` method, and its context, `ListCommandContext`. [[1]](diffhunk://#diff-26d76a3688ec3433d117a9d0ccf38abde3a944b869b2b4f6320f6aef429e1c7eR1-R28) [[2]](diffhunk://#diff-07796da1a5a6e66c20d69c62e450e47b58ec932ff5c41439dae428e77cbc02a1R1-R15) [[3]](diffhunk://#diff-64b55e883877097aa59481520da1a5e95db0c0ca1c343555b7aa0879046ef9e4R1-R19) [[4]](diffhunk://#diff-d14f4f17c3c754aa9b77fde48d701da249b552ec209c58c7542a5f7238baa19eR1-R4)

### Integration into Main Program

* Registered the new `DifferenceCommand` and `ListCommand` in the `main` function, including their associated context creation logic. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR79-R83) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR241-R258)
* Updated `main.cpp` to include the headers for the new commands.

### Enhancements to `Set` Class

* Added a new method, `differenceSet`, to the `Set` class to compute the difference between two sets. [[1]](diffhunk://#diff-9d36b5a7d015fe5a3d87ad5ef59367a99bbe53c647d6fcb1e9704ccf2d136dbfR443) [[2]](diffhunk://#diff-7f695ea923a774e1468ee0b31dcbb226ca86a98867a17ea7e9c2e67626ef96d8R370-R395)
* Refactored the `Set::show` method to display the set contents in a simpler format using in-order traversal.

### Code Cleanup

* Removed the unused `Set::show` method variant that displayed the tree structure.