### PR TITLE
Ref/command name

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/def/SetInfo.hpp
+++ b/def/SetInfo.hpp
@@ -8,12 +8,11 @@
 using std::string;
 
 struct SetInfo {
-	Set *set;
-	string origin;
+  Set *set;
+  string origin;
 
-	SetInfo() = default;
-	SetInfo(Set *set, const string &origin)
-		: set(set), origin(origin) {}
+  SetInfo() = default;
+  SetInfo(Set *set, const string &origin) : set(set), origin(origin) {}
 };
 
 #endif

--- a/def/StringValidatorArray.hpp
+++ b/def/StringValidatorArray.hpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-using StringValidator =
-    std::function<void(const std::string &)>;
+using StringValidator = std::function<void(const std::string &)>;
 
 #endif

--- a/include/Commander/Commands/ClearCommand.hpp
+++ b/include/Commander/Commands/ClearCommand.hpp
@@ -3,25 +3,25 @@
 
 #include <iostream>
 
-using std::string;
 using std::cout;
+using std::string;
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/ClearCommandContext.hpp"
 
 class ClearCommand : public Command {
 public:
-	/*
-	 * @brief ClearCommand constructor
-	 */
-	ClearCommand(const string& name, const string& description);
+  /*
+   * @brief ClearCommand constructor
+   */
+  ClearCommand(const string &name, const string &description);
 
-	/*
-	 * @brief ClearCommand execution function
-	 * 
-	 * @param context Command context
-	 */
-	void execute(CommandContext *context) const override;
+  /*
+   * @brief ClearCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/Command.hpp
+++ b/include/Commander/Commands/Command.hpp
@@ -5,8 +5,8 @@
 
 #include "Commander/Contexts/CommandContext.hpp"
 
-using std::string;
 using std::cout;
+using std::string;
 
 class Command {
 protected:
@@ -20,8 +20,7 @@ public:
    * @param n Command name
    * @param d Command description
    */
-  Command(const string &n, const string &d)
-      : name(n), description(d) {}
+  Command(const string &n, const string &d) : name(n), description(d) {}
 
   /**
    * @brief Returns the command name

--- a/include/Commander/Commands/ContainsCommand.hpp
+++ b/include/Commander/Commands/ContainsCommand.hpp
@@ -3,25 +3,25 @@
 
 #include <iostream>
 
-using std::string;
 using std::cout;
+using std::string;
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/ContainsCommandContext.hpp"
 
 class ContainsCommand : public Command {
 public:
-    /*
-     * @brief ContainsCommand constructor
-     */
-    ContainsCommand(const string& name, const string& description);
+  /*
+   * @brief ContainsCommand constructor
+   */
+  ContainsCommand(const string &name, const string &description);
 
-    /*
-     * @brief ContainsCommand execution function
-     * 
-     * @param context Command context
-     */
-    void execute(CommandContext *context) const override;
+  /*
+   * @brief ContainsCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/CreateCommand.hpp
+++ b/include/Commander/Commands/CreateCommand.hpp
@@ -1,30 +1,30 @@
 #ifndef CREATE_COMMAND_HPP
 #define CREATE_COMMAND_HPP
 
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/CreateCommandContext.hpp"
 
-using std::string;
 using std::cout;
+using std::string;
 using std::vector;
 
 class CreateCommand : public Command {
 public:
-	/*
-	 * @brief CreateCommand constructor
-	 */
-	CreateCommand(const string& name, const string& description);
+  /*
+   * @brief CreateCommand constructor
+   */
+  CreateCommand(const string &name, const string &description);
 
-	/*
-	 * @brief CreateCommand execution function
-	 * 
-	 * @param context Command context
-	 */
-	void execute(CommandContext *context) const override;
+  /*
+   * @brief CreateCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/DifferenceCommand.hpp
+++ b/include/Commander/Commands/DifferenceCommand.hpp
@@ -18,7 +18,7 @@ public:
 
   /*
    * @brief DifferenceCommand execution function
-   * 
+   *
    * @param context Command context
    */
   void execute(CommandContext *context) const override;

--- a/include/Commander/Commands/EmptyCommand.hpp
+++ b/include/Commander/Commands/EmptyCommand.hpp
@@ -3,25 +3,25 @@
 
 #include <iostream>
 
-using std::string;
 using std::cout;
+using std::string;
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/EmptyCommandContext.hpp"
 
 class EmptyCommand : public Command {
 public:
-	/*
-	 * @brief EmptyCommand constructor
-	 */
-	EmptyCommand(const string& name, const string& description);
+  /*
+   * @brief EmptyCommand constructor
+   */
+  EmptyCommand(const string &name, const string &description);
 
-	/*
-	 * @brief EmptyCommand execution function
-	 * 
-	 * @param context Command context
-	 */
-	void execute(CommandContext *context) const override;
+  /*
+   * @brief EmptyCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/HelpCommand.hpp
+++ b/include/Commander/Commands/HelpCommand.hpp
@@ -7,8 +7,8 @@
 #include "../def/UnorderedCommandMap.hpp"
 #include "Commander/Commands/Command.hpp"
 
-using std::string;
 using std::ostringstream;
+using std::string;
 
 class HelpCommand : public Command {
 private:

--- a/include/Commander/Commands/InsertCommand.hpp
+++ b/include/Commander/Commands/InsertCommand.hpp
@@ -3,25 +3,25 @@
 
 #include <iostream>
 
-using std::string;
 using std::cout;
+using std::string;
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/InsertCommandContext.hpp"
 
 class InsertCommand : public Command {
 public:
-	/*
-	 * @brief InsertCommand constructor
-	 */
-	InsertCommand(const string& name, const string& description);
+  /*
+   * @brief InsertCommand constructor
+   */
+  InsertCommand(const string &name, const string &description);
 
-	/*
-	 * @brief InsertCommand execution function
-	 * 
-	 * @param context Command context
-	 */
-	void execute(CommandContext *context) const override;
+  /*
+   * @brief InsertCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/IntersectionCommand.hpp
+++ b/include/Commander/Commands/IntersectionCommand.hpp
@@ -18,7 +18,7 @@ public:
 
   /*
    * @brief IntersectionCommand execution function
-   * 
+   *
    * @param context Command context
    */
   void execute(CommandContext *context) const override;

--- a/include/Commander/Commands/MinimumCommand.hpp
+++ b/include/Commander/Commands/MinimumCommand.hpp
@@ -3,25 +3,25 @@
 
 #include <iostream>
 
-using std::string;
 using std::cout;
+using std::string;
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/MinimumCommandContext.hpp"
 
 class MinimumCommand : public Command {
 public:
-	/*
-	 * @brief MinimumCommand constructor
-	 */
-	MinimumCommand(const string& name, const string& description);
+  /*
+   * @brief MinimumCommand constructor
+   */
+  MinimumCommand(const string &name, const string &description);
 
-	/*
-	 * @brief MinimumCommand execution function
-	 * 
-	 * @param context Command context
-	 */
-	void execute(CommandContext *context) const override;
+  /*
+   * @brief MinimumCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/ShowCommand.hpp
+++ b/include/Commander/Commands/ShowCommand.hpp
@@ -4,25 +4,25 @@
 #include <iostream>
 #include <string>
 
-using std::string;
 using std::cout;
+using std::string;
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/ShowCommandContext.hpp"
 
 class ShowCommand : public Command {
 public:
-	/*
-	 * @brief ShowCommand constructor
-	 */
-	ShowCommand(const string& name, const string& description);
+  /*
+   * @brief ShowCommand constructor
+   */
+  ShowCommand(const string &name, const string &description);
 
-	/*
-	 * @brief ShowCommand execution function
-	 * 
-	 * @param context Command context
-	 */
-	void execute(CommandContext *context) const override;
+  /*
+   * @brief ShowCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/SizeCommand.hpp
+++ b/include/Commander/Commands/SizeCommand.hpp
@@ -3,25 +3,25 @@
 
 #include <iostream>
 
-using std::string;
 using std::cout;
+using std::string;
 
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/SizeCommandContext.hpp"
 
 class SizeCommand : public Command {
 public:
-	/*
-	 * @brief SizeCommand constructor
-	 */
-	SizeCommand(const string& name, const string& description);
+  /*
+   * @brief SizeCommand constructor
+   */
+  SizeCommand(const string &name, const string &description);
 
-	/*
-	 * @brief SizeCommand execution function
-	 * 
-	 * @param context Command context
-	 */
-	void execute(CommandContext *context) const override;
+  /*
+   * @brief SizeCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/SwapCommand.hpp
+++ b/include/Commander/Commands/SwapCommand.hpp
@@ -6,22 +6,22 @@
 #include "Commander/Commands/Command.hpp"
 #include "Commander/Contexts/SwapCommandContext.hpp"
 
-using std::string;
 using std::cout;
+using std::string;
 
 class SwapCommand : public Command {
 public:
-   /**
-    * @briefSwapCommad constructor
-    */
-    SwapCommand(const string& name, const string& description);
+  /**
+   * @briefSwapCommad constructor
+   */
+  SwapCommand(const string &name, const string &description);
 
-   /*
-    * @brief ContainsCommand execution function
-    * 
-    * @param context Command context
-    */
-   void execute(CommandContext *context) const override;
+  /*
+   * @brief ContainsCommand execution function
+   *
+   * @param context Command context
+   */
+  void execute(CommandContext *context) const override;
 };
 
 #endif

--- a/include/Commander/Commands/UnionCommand.hpp
+++ b/include/Commander/Commands/UnionCommand.hpp
@@ -17,7 +17,7 @@ public:
   UnionCommand(const string &name, const string &description);
   /*
    * @brief UnionCommand execution function
-   * 
+   *
    * @param context Command context
    */
   void execute(CommandContext *context) const override;

--- a/include/Commander/Contexts/ClearCommandContext.hpp
+++ b/include/Commander/Contexts/ClearCommandContext.hpp
@@ -5,7 +5,7 @@
 
 class ClearCommandContext : public IndexedCommandContext {
 public:
-    ClearCommandContext(ConstRepository repository, int index);
+  ClearCommandContext(ConstRepository repository, int index);
 };
 
 #endif

--- a/include/Commander/Contexts/CommandContext.hpp
+++ b/include/Commander/Contexts/CommandContext.hpp
@@ -3,10 +3,10 @@
 
 class CommandContext {
 public:
-	/**
-	 * @brief Context destructor
-	 */
-	virtual ~CommandContext() = default;
+  /**
+   * @brief Context destructor
+   */
+  virtual ~CommandContext() = default;
 };
 
 #endif

--- a/include/Commander/Contexts/ContainsCommandContext.hpp
+++ b/include/Commander/Contexts/ContainsCommandContext.hpp
@@ -5,9 +5,9 @@
 
 class ContainsCommandContext : public IndexedCommandContext {
 public:
-    int key;
+  int key;
 
-    ContainsCommandContext(ConstRepository repository, int index, int key);
+  ContainsCommandContext(ConstRepository repository, int index, int key);
 };
 
 #endif

--- a/include/Commander/Contexts/CreateCommandContext.hpp
+++ b/include/Commander/Contexts/CreateCommandContext.hpp
@@ -6,8 +6,8 @@
 #include "../def/Repository.hpp"
 #include "Commander/Contexts/CommandContext.hpp"
 
-using std::string;
 using std::queue;
+using std::string;
 
 class CreateCommandContext : public CommandContext {
 public:
@@ -15,7 +15,8 @@ public:
   queue<int> initialData;
   string origin;
 
-  CreateCommandContext(Repository repository, queue<int>& initialData, const string& origin);
+  CreateCommandContext(Repository repository, queue<int> &initialData,
+                       const string &origin);
 };
 
 #endif

--- a/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
+++ b/include/Commander/Contexts/DoubleIndexedCommandContext.hpp
@@ -9,9 +9,8 @@ public:
   R repository;
   int index1;
   int index2;
-  
-  DoubleIndexedCommandContext(R repository, int index1,
-                              int index2)
+
+  DoubleIndexedCommandContext(R repository, int index1, int index2)
       : repository(repository), index1(index1), index2(index2) {}
 };
 

--- a/include/Commander/Contexts/IndexedCommandContext.hpp
+++ b/include/Commander/Contexts/IndexedCommandContext.hpp
@@ -6,12 +6,12 @@
 
 class IndexedCommandContext : public CommandContext {
 public:
-    int index;
+  int index;
 
-    ConstRepository repository;
+  ConstRepository repository;
 
-    IndexedCommandContext(ConstRepository repository, int index)
-        : repository(repository), index(index) {}
+  IndexedCommandContext(ConstRepository repository, int index)
+      : repository(repository), index(index) {}
 };
 
 #endif

--- a/include/Commander/Contexts/InsertCommandContext.hpp
+++ b/include/Commander/Contexts/InsertCommandContext.hpp
@@ -5,9 +5,9 @@
 
 class InsertCommandContext : public IndexedCommandContext {
 public:
-	int value;
+  int value;
 
-    InsertCommandContext(ConstRepository repository, int index, int value);
+  InsertCommandContext(ConstRepository repository, int index, int value);
 };
 
 #endif

--- a/include/Commander/Contexts/PredecessorCommandContext.hpp
+++ b/include/Commander/Contexts/PredecessorCommandContext.hpp
@@ -8,7 +8,7 @@ using std::string;
 class PredecessorCommandContext : public IndexedCommandContext {
 public:
   int key;
-  
+
   PredecessorCommandContext(ConstRepository repository, int index, int key);
 };
 

--- a/include/Commander/Contexts/ShowCommandContext.hpp
+++ b/include/Commander/Contexts/ShowCommandContext.hpp
@@ -6,15 +6,15 @@
 #include "../def/ConstRepository.hpp"
 #include "Commander/Contexts/CommandContext.hpp"
 
-using std::string;
 using std::queue;
+using std::string;
 
 class ShowCommandContext : public CommandContext {
 public:
   queue<int> indexes;
   ConstRepository repository;
 
-  ShowCommandContext(ConstRepository repository, const queue<int>& indexes);
+  ShowCommandContext(ConstRepository repository, const queue<int> &indexes);
 };
 
 #endif

--- a/include/Commander/Invoker/CommandInvoker.hpp
+++ b/include/Commander/Invoker/CommandInvoker.hpp
@@ -1,9 +1,9 @@
 #ifndef INVOKER_HPP
 #define INVOKER_HPP
 
-#include "Messages/InvalidCommandMessage.hpp"
-#include "Exceptions/InvalidCommandException.hpp"
 #include "Commander/Commands/HelpCommand.hpp"
+#include "Exceptions/InvalidCommandException.hpp"
+#include "Messages/InvalidCommandMessage.hpp"
 
 using std::string;
 

--- a/include/Exceptions/EmptyRepositoryException.hpp
+++ b/include/Exceptions/EmptyRepositoryException.hpp
@@ -3,8 +3,8 @@
 
 #include <stdexcept>
 
-using std::string;
 using std::runtime_error;
+using std::string;
 
 class EmptyRepositoryException : public runtime_error {
 public:

--- a/include/Exceptions/InvalidArgumentException.hpp
+++ b/include/Exceptions/InvalidArgumentException.hpp
@@ -3,8 +3,8 @@
 
 #include <stdexcept>
 
-using std::string;
 using std::invalid_argument;
+using std::string;
 
 class InvalidArgumentException : public std::invalid_argument {
 public:

--- a/include/Exceptions/InvalidIndexException.hpp
+++ b/include/Exceptions/InvalidIndexException.hpp
@@ -4,8 +4,8 @@
 
 #include <stdexcept>
 
-using std::string;
 using std::invalid_argument;
+using std::string;
 
 class InvalidIndexException : public invalid_argument {
 public:

--- a/include/Exceptions/InvalidIndexStringException.hpp
+++ b/include/Exceptions/InvalidIndexStringException.hpp
@@ -3,8 +3,8 @@
 
 #include <stdexcept>
 
-using std::string;
 using std::invalid_argument;
+using std::string;
 
 class InvalidIndexStringException : public invalid_argument {
 public:

--- a/include/Exceptions/InvalidNumberInputException.hpp
+++ b/include/Exceptions/InvalidNumberInputException.hpp
@@ -4,10 +4,10 @@
 #include <stdexcept>
 #include <string>
 
-using std::string;
+using std::exception;
 using std::invalid_argument;
 using std::stoi;
-using std::exception;
+using std::string;
 
 class InvalidNumberInputException : public invalid_argument {
 public:

--- a/include/Messages/InvalidIndexStringMessage.hpp
+++ b/include/Messages/InvalidIndexStringMessage.hpp
@@ -6,9 +6,11 @@
 using std::string;
 
 /**
- * @brief message to be displayed when a string contains at least one invalid index
- * 
- * An index is considered invalid when it is negative (covered by size_t) or when the index exceeds the limits of the vector
+ * @brief message to be displayed when a string contains at least one invalid
+ * index
+ *
+ * An index is considered invalid when it is negative (covered by size_t) or
+ * when the index exceeds the limits of the vector
  */
 string InvalidIndexStringMessage();
 

--- a/include/Node/Node.hpp
+++ b/include/Node/Node.hpp
@@ -3,24 +3,24 @@
 
 /**
  * @class Node
- * 
+ *
  * Esta estrutura representa um nó qualquer da árvore
  * */
 struct Node {
-	int key;
-	int height;
-	Node* left;
-	Node* right;
+  int key;
+  int height;
+  Node *left;
+  Node *right;
 
-	/**
-	 * @brief Construtor do nó
-	 * 
-	 * Cria um nó com uma valor `key` e uma altura especificada, se necessário
-	 * 
-	 * @param key O valor do nó
-	 * @param height A altura do nó
-	 * */
-	Node(int key, int height = 1);
+  /**
+   * @brief Construtor do nó
+   *
+   * Cria um nó com uma valor `key` e uma altura especificada, se necessário
+   *
+   * @param key O valor do nó
+   * @param height A altura do nó
+   * */
+  Node(int key, int height = 1);
 };
 
 #endif

--- a/include/Set/Set.hpp
+++ b/include/Set/Set.hpp
@@ -215,7 +215,8 @@ private:
   void unionSet(Node *t1, Node *t2, Set &U) const;
 
   /**
-   * @brief Performs an in-order traversal of the subtree and appends node keys to a vector.
+   * @brief Performs an in-order traversal of the subtree and appends node keys
+   * to a vector.
    *
    * Recursively visits the left child, records the current node’s key, and then
    * visits the right child, resulting in a sorted sequence of keys.
@@ -428,12 +429,13 @@ public:
   /**
    * @brief Computes the set difference of this set and another.
    *
-   * This function returns a new set containing elements that belong to the current set
-   * but not to the given set `T`. Both sets are traversed in sorted order to efficiently
-   * identify and insert unique elements into the result.
+   * This function returns a new set containing elements that belong to the
+   * current set but not to the given set `T`. Both sets are traversed in sorted
+   * order to efficiently identify and insert unique elements into the result.
    *
    * @param T The set to subtract from the current set.
-   * @return Set* A pointer to a new set containing elements in this set that are not in `T`.
+   * @return Set* A pointer to a new set containing elements in this set that
+   * are not in `T`.
    */
   Set *differenceSet(const Set &T) const;
 #ifdef TEST_MODE

--- a/include/Utils/IO/PromptMultipleIndexes.hpp
+++ b/include/Utils/IO/PromptMultipleIndexes.hpp
@@ -1,23 +1,23 @@
 #ifndef PROMPT_MULTIPLE_INDEXES
-#define PROMPT_MULTIPLE_INDEXES 
+#define PROMPT_MULTIPLE_INDEXES
 
 #include <queue>
 
 #include "../def/ConstRepository.hpp"
 #include "Utils/Tools/GetValidString.hpp"
-#include "Utils/Validation/ValidateOnlyIntegers.hpp"
 #include "Utils/Validation/ValidateIndexes.hpp"
+#include "Utils/Validation/ValidateOnlyIntegers.hpp"
 
+using std::istringstream;
 using std::queue;
 using std::string;
-using std::istringstream;
 
 /**
  * @brief Prompts the user for multiple set indexes and validates them.
  *
  * This function prompts the user with a given message, validates that the input
- * contains only integers and that each index is within the valid repository range.
- * It then returns the validated indexes stored in a queue.
+ * contains only integers and that each index is within the valid repository
+ * range. It then returns the validated indexes stored in a queue.
  *
  * @param repository The repository containing the sets.
  * @param prompt The message to display to the user.
@@ -25,6 +25,7 @@ using std::istringstream;
  * @throws InvalidNumberInputException if non-integer input is provided.
  * @throws InvalidIndexException if any index is out of bounds.
  */
-queue<int> promptMultipleIndexes(ConstRepository repository, const string& prompt);
+queue<int> promptMultipleIndexes(ConstRepository repository,
+                                 const string &prompt);
 
 #endif

--- a/include/Utils/IO/PromptValidIndex.hpp
+++ b/include/Utils/IO/PromptValidIndex.hpp
@@ -1,5 +1,5 @@
 #ifndef PROMPT_VALID_INDEX_HPP
-#define PROMPT_VALID_INDEX_HPP 
+#define PROMPT_VALID_INDEX_HPP
 
 #include "../def/ConstRepository.hpp"
 #include "Utils/Tools/GetValidNumber.hpp"
@@ -8,7 +8,8 @@
 using std::string;
 
 /**
- * @brief Prompts the user with a message and retrieves a validated repository index.
+ * @brief Prompts the user with a message and retrieves a validated repository
+ * index.
  *
  * This function displays the given prompt, reads an integer from the user,
  * and ensures it falls within the valid range [0, repository.size()). It uses
@@ -18,6 +19,6 @@ using std::string;
  * @param prompt The message displayed to the user when requesting input.
  * @return int A valid index within the repository.
  */
-int promptValidIndex(ConstRepository repository, const string& prompt);
+int promptValidIndex(ConstRepository repository, const string &prompt);
 
 #endif

--- a/include/Utils/Tools/GetValidNumber.hpp
+++ b/include/Utils/Tools/GetValidNumber.hpp
@@ -6,27 +6,27 @@
 #include "Messages/InvalidArgumentForNumberMessage.hpp"
 #include "Utils/Tools/IgnoreCin.hpp"
 
-using std::string;
-using std::cout;
 using std::cin;
+using std::cout;
 using std::exception;
+using std::string;
 
 /**
  * @brief Reads a valid integer from the user
  *
- * This function goes into an infinite loop unless the user types something valid.
- * Something is defined as valid in the parameter that receives a series of validations
- * given by the program, making it flexible for various cases. I.e., there will always be
- * a valid value. Furthermore, this function only handles integer requests. If
- * needed is a function that reads another value, another function must be created.
+ * This function goes into an infinite loop unless the user types something
+ * valid. Something is defined as valid in the parameter that receives a series
+ * of validations given by the program, making it flexible for various cases.
+ * I.e., there will always be a valid value. Furthermore, this function only
+ * handles integer requests. If needed is a function that reads another value,
+ * another function must be created.
  *
  * @param prompt The message asking what you want from the user
- * @param validations A series of validations that will indicate whether the answer given is
- * valid
+ * @param validations A series of validations that will indicate whether the
+ * answer given is valid
  *
  * @throws InvalidArgumentException If the user types something invalid
  */
-int getValidNumber(const string &prompt,
-                   const IntValidator validations);
+int getValidNumber(const string &prompt, const IntValidator validations);
 
 #endif

--- a/include/Utils/Tools/GetValidString.hpp
+++ b/include/Utils/Tools/GetValidString.hpp
@@ -7,10 +7,10 @@
 #include "Exceptions/InvalidArgumentException.hpp"
 #include "Utils/Tools/Trim.hpp"
 
-using std::string;
-using std::cout;
 using std::cin;
+using std::cout;
 using std::exception;
+using std::string;
 
 /**
  * @brief Gets a valid string

--- a/include/Utils/Tools/Trim.hpp
+++ b/include/Utils/Tools/Trim.hpp
@@ -3,11 +3,11 @@
 
 #include <algorithm>
 #include <cctype>
-#include <string>
 #include <regex>
+#include <string>
 
-using std::string;
 using std::regex;
+using std::string;
 
 /**
  * @brief Removes whitespace from the beginning and end of a string

--- a/include/Utils/Validation/ValidateIndex.hpp
+++ b/include/Utils/Validation/ValidateIndex.hpp
@@ -7,8 +7,9 @@
 /**
  * @brief Validates whether an index is within the valid range of a repository.
  *
- * This function checks if the given index is non-negative and less than the repository size.
- * If the index is out of bounds, it throws an `InvalidIndexException`.
+ * This function checks if the given index is non-negative and less than the
+ * repository size. If the index is out of bounds, it throws an
+ * `InvalidIndexException`.
  *
  * @param index The index to validate.
  * @param repositorySize The size of the repository to validate against.

--- a/include/Utils/Validation/ValidateIndexes.hpp
+++ b/include/Utils/Validation/ValidateIndexes.hpp
@@ -1,17 +1,18 @@
 #ifndef VALIDATE_INDEXES
-#define VALIDATE_INDEXES 
+#define VALIDATE_INDEXES
 
 #include "Exceptions/InvalidIndexStringException.hpp"
 #include "Messages/InvalidIndexStringMessage.hpp"
 
-#include <string>
 #include <sstream>
+#include <string>
 
-using std::string;
 using std::istringstream;
+using std::string;
 
 /**
- * @brief Validates that each index in the input string is within the valid range.
+ * @brief Validates that each index in the input string is within the valid
+ * range.
  *
  * This function parses the provided string for integer tokens and ensures
  * that each index is between 0 (inclusive) and repositorySize (exclusive).

--- a/include/Utils/Validation/ValidateOnlyIntegers.hpp
+++ b/include/Utils/Validation/ValidateOnlyIntegers.hpp
@@ -1,26 +1,28 @@
 #ifndef VALIDATE_ONLY_INTEGERS_HPP
 #define VALIDATE_ONLY_INTEGERS_HPP
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #include "Exceptions/InvalidNumberInputException.hpp"
 #include "Messages/InvalidNumberInputMessage.hpp"
 
-using std::istringstream;
 using std::isdigit;
+using std::istringstream;
 
 /**
- * @brief Validates whether a string contains only integer tokens separated by spaces.
+ * @brief Validates whether a string contains only integer tokens separated by
+ * spaces.
  *
  * This function reads the input string token by token and checks if each token
- * consists only of digit characters. If any token is invalid, it throws an exception.
- * The function ensures that the entire string is processed and only valid integer tokens
- * are present.
+ * consists only of digit characters. If any token is invalid, it throws an
+ * exception. The function ensures that the entire string is processed and only
+ * valid integer tokens are present.
  *
  * @param str The string to validate.
- * @throws InvalidNumberInputException if the string contains non-integer tokens or is improperly formatted.
+ * @throws InvalidNumberInputException if the string contains non-integer tokens
+ * or is improperly formatted.
  */
-void ValidateOnlyIntegers(const string& str);
+void ValidateOnlyIntegers(const string &str);
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -75,7 +75,7 @@ int main() {
       "successor", "exibe o sucessor de um dado numero de um conjunto");
   UnionCommand unionCommand("union", "une dois conjuntos do sistema");
   IntersectionCommand intersectionCommand(
-      "intersecao", "reune os elementos em comum de dois conjuntos do sistema");
+      "intersection", "reune os elementos em comum de dois conjuntos do sistema");
   DifferenceCommand differenceCommand(
       "difference", "extrai todos os elementos exclusivos do primeiro em "
                     "relacao a uniao de dois conjuntos no sistema");

--- a/main.cpp
+++ b/main.cpp
@@ -46,7 +46,6 @@
 using std::cin;
 using std::exception;
 using std::getline;
-// using std::endl;
 
 int main() {
   CommandInvoker invoker;
@@ -75,7 +74,8 @@ int main() {
       "successor", "exibe o sucessor de um dado numero de um conjunto");
   UnionCommand unionCommand("union", "une dois conjuntos do sistema");
   IntersectionCommand intersectionCommand(
-      "intersection", "reune os elementos em comum de dois conjuntos do sistema");
+      "intersection",
+      "reune os elementos em comum de dois conjuntos do sistema");
   DifferenceCommand differenceCommand(
       "difference", "extrai todos os elementos exclusivos do primeiro em "
                     "relacao a uniao de dois conjuntos no sistema");

--- a/src/Commander/Commands/ClearCommand.cpp
+++ b/src/Commander/Commands/ClearCommand.cpp
@@ -1,17 +1,16 @@
 #include "Commander/Commands/ClearCommand.hpp"
 
-ClearCommand::ClearCommand(const string &name,
-                                     const string &description)
+ClearCommand::ClearCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void ClearCommand::execute(CommandContext *context) const {
   auto *ctx = dynamic_cast<ClearCommandContext *>(context);
 
   if (ctx) {
-  	ConstRepository repo = ctx->repository;
-  	int index = ctx->index;
+    ConstRepository repo = ctx->repository;
+    int index = ctx->index;
 
-  	repo[index].set->clear();
+    repo[index].set->clear();
 
     cout << "O conjunto " << index << " foi limpo com sucesso." << '\n';
   }

--- a/src/Commander/Commands/ContainsCommand.cpp
+++ b/src/Commander/Commands/ContainsCommand.cpp
@@ -1,8 +1,7 @@
 
 #include "Commander/Commands/ContainsCommand.hpp"
 
-ContainsCommand::ContainsCommand(const string &name,
-                                     const string &description)
+ContainsCommand::ContainsCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void ContainsCommand::execute(CommandContext *context) const {
@@ -11,6 +10,8 @@ void ContainsCommand::execute(CommandContext *context) const {
   if (ctx) {
     int index = ctx->index, key = ctx->key;
 
-    cout << "O conjunto " << index << (ctx->repository[index].set->contains(key) ? " " : " nao ") << "contem o valor " << key << '\n';
+    cout << "O conjunto " << index
+         << (ctx->repository[index].set->contains(key) ? " " : " nao ")
+         << "contem o valor " << key << '\n';
   }
 }

--- a/src/Commander/Commands/CreateCommand.cpp
+++ b/src/Commander/Commands/CreateCommand.cpp
@@ -1,7 +1,6 @@
 #include "Commander/Commands/CreateCommand.hpp"
 
-CreateCommand::CreateCommand(const string &name,
-                                     const string &description)
+CreateCommand::CreateCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void CreateCommand::execute(CommandContext *context) const {
@@ -16,6 +15,7 @@ void CreateCommand::execute(CommandContext *context) const {
     }
 
     ctx->repository.emplace_back(set, "gerado por linha de comando");
-    cout << "Conjunto adicionado com sucesso na posição " << ctx->repository.size() - 1 << '\n';
+    cout << "Conjunto adicionado com sucesso na posição "
+         << ctx->repository.size() - 1 << '\n';
   }
 }

--- a/src/Commander/Commands/EmptyCommand.cpp
+++ b/src/Commander/Commands/EmptyCommand.cpp
@@ -1,16 +1,16 @@
 #include "Commander/Commands/EmptyCommand.hpp"
 
-EmptyCommand::EmptyCommand(const string &name,
-                                     const string &description)
+EmptyCommand::EmptyCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void EmptyCommand::execute(CommandContext *context) const {
   auto *ctx = dynamic_cast<EmptyCommandContext *>(context);
 
   if (ctx) {
-  	ConstRepository repo = ctx->repository;
-  	int index = ctx->index;
+    ConstRepository repo = ctx->repository;
+    int index = ctx->index;
 
-    cout << "O conjunto " << index << (repo[index].set->empty() ? " " : " nao ") << "esta vazio." << '\n';
+    cout << "O conjunto " << index << (repo[index].set->empty() ? " " : " nao ")
+         << "esta vazio." << '\n';
   }
 }

--- a/src/Commander/Commands/HelpCommand.cpp
+++ b/src/Commander/Commands/HelpCommand.cpp
@@ -1,7 +1,6 @@
 #include "Commander/Commands/HelpCommand.hpp"
 
-HelpCommand::HelpCommand(const string &name,
-                         const string &description,
+HelpCommand::HelpCommand(const string &name, const string &description,
                          const UnorderedMapCommand &mapCommand)
     : Command(name, description), commandRegistry(mapCommand) {}
 

--- a/src/Commander/Commands/InsertCommand.cpp
+++ b/src/Commander/Commands/InsertCommand.cpp
@@ -1,17 +1,16 @@
 #include "Commander/Commands/InsertCommand.hpp"
 
-InsertCommand::InsertCommand(const string &name,
-                                     const string &description)
+InsertCommand::InsertCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void InsertCommand::execute(CommandContext *context) const {
   auto *ctx = dynamic_cast<InsertCommandContext *>(context);
 
   if (ctx) {
-  	ConstRepository repo = ctx->repository;
-  	int index = ctx->index, value = ctx->value;
+    ConstRepository repo = ctx->repository;
+    int index = ctx->index, value = ctx->value;
 
-  	repo[index].set->insert(value);
+    repo[index].set->insert(value);
 
     cout << "Elemento " << value << " adicionado no conjunto " << index << '\n';
   }

--- a/src/Commander/Commands/PredecessorCommand.cpp
+++ b/src/Commander/Commands/PredecessorCommand.cpp
@@ -1,6 +1,7 @@
 #include "Commander/Commands/PredecessorCommand.hpp"
 
-PredecessorCommand::PredecessorCommand(const string &name, const string &description)
+PredecessorCommand::PredecessorCommand(const string &name,
+                                       const string &description)
     : Command(name, description) {}
 
 void PredecessorCommand::execute(CommandContext *context) const {
@@ -11,8 +12,8 @@ void PredecessorCommand::execute(CommandContext *context) const {
     int index = ctx->index, key = ctx->key;
 
     int pred = repo[index].set->predecessor(key);
-    
-    cout << "O antecessor de  " << key << " eh "
-         << pred << " no conjunto " << index << '\n';
+
+    cout << "O antecessor de  " << key << " eh " << pred << " no conjunto "
+         << index << '\n';
   }
 }

--- a/src/Commander/Commands/ShowCommand.cpp
+++ b/src/Commander/Commands/ShowCommand.cpp
@@ -1,29 +1,28 @@
 #include "Commander/Commands/ShowCommand.hpp"
 
-ShowCommand::ShowCommand(const string &name,
-                                     const string &description)
+ShowCommand::ShowCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void ShowCommand::execute(CommandContext *context) const {
   auto *ctx = dynamic_cast<ShowCommandContext *>(context);
 
   if (ctx) {
-  	ConstRepository repo = ctx->repository;
-  	queue<int> setIndexes = ctx->indexes;
+    ConstRepository repo = ctx->repository;
+    queue<int> setIndexes = ctx->indexes;
 
     if (setIndexes.empty())
       for (size_t i = 0; i < repo.size(); i++)
         setIndexes.push(i);
 
-  	while (!setIndexes.empty()) {
-  		int index = setIndexes.front();
+    while (!setIndexes.empty()) {
+      int index = setIndexes.front();
 
       cout << "Conjunto " << index << '\n';
 
-  		repo[index].set->show();
+      repo[index].set->show();
       cout << '\n';
 
-  		setIndexes.pop();
-  	}
+      setIndexes.pop();
+    }
   }
 }

--- a/src/Commander/Commands/SizeCommand.cpp
+++ b/src/Commander/Commands/SizeCommand.cpp
@@ -1,16 +1,16 @@
 #include "Commander/Commands/SizeCommand.hpp"
 
-SizeCommand::SizeCommand(const string &name,
-                                     const string &description)
+SizeCommand::SizeCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void SizeCommand::execute(CommandContext *context) const {
   auto *ctx = dynamic_cast<SizeCommandContext *>(context);
 
   if (ctx) {
-  	ConstRepository repo = ctx->repository;
-  	int index = ctx->index;
+    ConstRepository repo = ctx->repository;
+    int index = ctx->index;
 
-    cout << "O tamanho do conjunto " << index << " eh " << repo[index].set->size() << '\n';
+    cout << "O tamanho do conjunto " << index << " eh "
+         << repo[index].set->size() << '\n';
   }
 }

--- a/src/Commander/Commands/SuccessorCommand.cpp
+++ b/src/Commander/Commands/SuccessorCommand.cpp
@@ -1,6 +1,7 @@
 #include "Commander/Commands/SuccessorCommand.hpp"
 
-SuccessorCommand::SuccessorCommand(const string &name, const string &description)
+SuccessorCommand::SuccessorCommand(const string &name,
+                                   const string &description)
     : Command(name, description) {}
 
 void SuccessorCommand::execute(CommandContext *context) const {
@@ -11,8 +12,8 @@ void SuccessorCommand::execute(CommandContext *context) const {
     int index = ctx->index, key = ctx->key;
 
     int pred = repo[index].set->successor(key);
-    
-    cout << "O sucessor de  " << key << " eh "
-         << pred << " no conjunto " << index << '\n';
+
+    cout << "O sucessor de  " << key << " eh " << pred << " no conjunto "
+         << index << '\n';
   }
 }

--- a/src/Commander/Commands/SwapCommand.cpp
+++ b/src/Commander/Commands/SwapCommand.cpp
@@ -1,17 +1,18 @@
 #include "Commander/Commands/SwapCommand.hpp"
 
-SwapCommand::SwapCommand(const string& name, const string& description)
+SwapCommand::SwapCommand(const string &name, const string &description)
     : Command(name, description) {}
 
 void SwapCommand::execute(CommandContext *context) const {
-    auto *ctx = dynamic_cast<SwapCommandContext *>(context);
-    
-    if (ctx) {
-        ConstRepository repo = ctx->repository;
-        int index1 = ctx->index1, index2 = ctx->index2;
-        
-        repo[index1].set->swap(*(repo[index2].set));
-        
-        cout << "O conjunto " << index1 << " foi trocado com o conjunto " << index2 << '\n';
-    }
-}   
+  auto *ctx = dynamic_cast<SwapCommandContext *>(context);
+
+  if (ctx) {
+    ConstRepository repo = ctx->repository;
+    int index1 = ctx->index1, index2 = ctx->index2;
+
+    repo[index1].set->swap(*(repo[index2].set));
+
+    cout << "O conjunto " << index1 << " foi trocado com o conjunto " << index2
+         << '\n';
+  }
+}

--- a/src/Commander/Contexts/ContainsCommandContext.cpp
+++ b/src/Commander/Contexts/ContainsCommandContext.cpp
@@ -1,4 +1,5 @@
 #include "Commander/Contexts/ContainsCommandContext.hpp"
 
-ContainsCommandContext::ContainsCommandContext(ConstRepository repository, int index, int key)
+ContainsCommandContext::ContainsCommandContext(ConstRepository repository,
+                                               int index, int key)
     : IndexedCommandContext(repository, index), key(key) {}

--- a/src/Commander/Contexts/CreateCommandContext.cpp
+++ b/src/Commander/Contexts/CreateCommandContext.cpp
@@ -1,4 +1,6 @@
 #include "Commander/Contexts/CreateCommandContext.hpp"
 
-CreateCommandContext::CreateCommandContext(Repository repository, queue<int>& initialData, const string& origin)
-	: repository(repository), initialData(initialData), origin(origin) {}
+CreateCommandContext::CreateCommandContext(Repository repository,
+                                           queue<int> &initialData,
+                                           const string &origin)
+    : repository(repository), initialData(initialData), origin(origin) {}

--- a/src/Commander/Contexts/EmptyCommandContext.cpp
+++ b/src/Commander/Contexts/EmptyCommandContext.cpp
@@ -1,4 +1,4 @@
 #include "Commander/Contexts/EmptyCommandContext.hpp"
 
 EmptyCommandContext::EmptyCommandContext(ConstRepository repository, int index)
-	: IndexedCommandContext(repository, index) {}
+    : IndexedCommandContext(repository, index) {}

--- a/src/Commander/Contexts/InsertCommandContext.cpp
+++ b/src/Commander/Contexts/InsertCommandContext.cpp
@@ -1,4 +1,5 @@
 #include "Commander/Contexts/InsertCommandContext.hpp"
 
-InsertCommandContext::InsertCommandContext(ConstRepository repository, int index, int value)
+InsertCommandContext::InsertCommandContext(ConstRepository repository,
+                                           int index, int value)
     : IndexedCommandContext(repository, index), value(value) {}

--- a/src/Commander/Contexts/ShowCommandContext.cpp
+++ b/src/Commander/Contexts/ShowCommandContext.cpp
@@ -1,4 +1,5 @@
 #include "Commander/Contexts/ShowCommandContext.hpp"
 
-ShowCommandContext::ShowCommandContext(ConstRepository repository, const queue<int> &indexes)
-	: repository(repository), indexes(indexes) {}
+ShowCommandContext::ShowCommandContext(ConstRepository repository,
+                                       const queue<int> &indexes)
+    : repository(repository), indexes(indexes) {}

--- a/src/Commander/Contexts/SizeCommandContext.cpp
+++ b/src/Commander/Contexts/SizeCommandContext.cpp
@@ -1,4 +1,4 @@
 #include "Commander/Contexts/SizeCommandContext.hpp"
 
 SizeCommandContext::SizeCommandContext(ConstRepository repository, int index)
-	: IndexedCommandContext(repository, index) {}
+    : IndexedCommandContext(repository, index) {}

--- a/src/Commander/Contexts/SuccessorCommandContext.cpp
+++ b/src/Commander/Contexts/SuccessorCommandContext.cpp
@@ -1,5 +1,5 @@
 #include "Commander/Contexts/SuccessorCommandContext.hpp"
 
 SuccessorCommandContext::SuccessorCommandContext(ConstRepository repository,
-                                                     int index, int key)
+                                                 int index, int key)
     : IndexedCommandContext(repository, index), key(key) {}

--- a/src/Messages/EmptyRepositoryMessage.cpp
+++ b/src/Messages/EmptyRepositoryMessage.cpp
@@ -1,5 +1,6 @@
 #include "Messages/EmptyRepositoryMessage.hpp"
 
 string EmptyRepositoryMessage() {
-  return "Nao foi possivel realizar a operacao. Nenhum conjunto foi criado no sistema";
+  return "Nao foi possivel realizar a operacao. Nenhum conjunto foi criado no "
+         "sistema";
 }

--- a/src/Messages/InvalidCommandMessage.cpp
+++ b/src/Messages/InvalidCommandMessage.cpp
@@ -1,5 +1,5 @@
 #include "Messages/InvalidCommandMessage.hpp"
 
 string InvalidCommandMessage() {
-	return "Comando invalido! Use o comando 'help' para listar todos os comandos";
+  return "Comando invalido! Use o comando 'help' para listar todos os comandos";
 }

--- a/src/Messages/InvalidIndexMessage.cpp
+++ b/src/Messages/InvalidIndexMessage.cpp
@@ -2,5 +2,6 @@
 #include "Messages/InvalidIndexMessage.hpp"
 
 string InvalidIndexMessage() {
-  return "Hum... esse número não corresponde a nenhum conjunto. Poderia verificar qual o índice correto?";
+  return "Hum... esse número não corresponde a nenhum conjunto. Poderia "
+         "verificar qual o índice correto?";
 }

--- a/src/Messages/InvalidIndexStringMessage.cpp
+++ b/src/Messages/InvalidIndexStringMessage.cpp
@@ -1,5 +1,6 @@
 #include "Messages/InvalidIndexStringMessage.hpp"
 
 string InvalidIndexStringMessage() {
-  return "Alguns dos índices que você informou não são válidos. Redigite os índices, por favor.";
+  return "Alguns dos índices que você informou não são válidos. Redigite os "
+         "índices, por favor.";
 }

--- a/src/Messages/InvalidNumberInputMessage.cpp
+++ b/src/Messages/InvalidNumberInputMessage.cpp
@@ -1,5 +1,6 @@
 #include "Messages/InvalidNumberInputMessage.hpp"
 
 string InvalidNumberInputMessage() {
-  return "Oops! Parece que você digitou algo além de números. Tente novamente, por favor.";
+  return "Oops! Parece que você digitou algo além de números. Tente novamente, "
+         "por favor.";
 }

--- a/src/Node/Node.cpp
+++ b/src/Node/Node.cpp
@@ -1,4 +1,4 @@
 #include "Node/Node.hpp"
 
-Node::Node(int key, int height):
-	key(key), height(height), left(nullptr), right(nullptr) {}
+Node::Node(int key, int height)
+    : key(key), height(height), left(nullptr), right(nullptr) {}

--- a/src/Utils/IO/PromptMultipleIndexes.cpp
+++ b/src/Utils/IO/PromptMultipleIndexes.cpp
@@ -1,15 +1,16 @@
 #include "Utils/IO/PromptMultipleIndexes.hpp"
 
-queue<int> promptMultipleIndexes(ConstRepository repository, const string& prompt) {
-	istringstream bufferedData(getValidString(prompt,
-		[&](const string& data) {
-			ValidateOnlyIntegers(data);
-			ValidateIndexes(data, repository.size());
-		}));
+queue<int> promptMultipleIndexes(ConstRepository repository,
+                                 const string &prompt) {
+  istringstream bufferedData(getValidString(prompt, [&](const string &data) {
+    ValidateOnlyIntegers(data);
+    ValidateIndexes(data, repository.size());
+  }));
 
-	int num;
-	queue<int> result;
-	while (bufferedData >> num) result.push(num);
+  int num;
+  queue<int> result;
+  while (bufferedData >> num)
+    result.push(num);
 
-	return result;
+  return result;
 }

--- a/src/Utils/IO/PromptValidIndex.cpp
+++ b/src/Utils/IO/PromptValidIndex.cpp
@@ -1,7 +1,6 @@
 #include "Utils/IO/PromptValidIndex.hpp"
 
-int promptValidIndex(ConstRepository repository, const string& prompt) {
-	return getValidNumber(prompt, [&](int data) {
-		ValidateIndex(data, repository.size());
-	});
+int promptValidIndex(ConstRepository repository, const string &prompt) {
+  return getValidNumber(
+      prompt, [&](int data) { ValidateIndex(data, repository.size()); });
 }

--- a/src/Utils/Tools/GetValidNumber.cpp
+++ b/src/Utils/Tools/GetValidNumber.cpp
@@ -1,7 +1,6 @@
 #include "Utils/Tools/GetValidNumber.hpp"
 
-int getValidNumber(const string &prompt,
-                   const IntValidator validations) {
+int getValidNumber(const string &prompt, const IntValidator validations) {
   int num = -1;
 
   while (true) {

--- a/src/Utils/Tools/GetValidString.cpp
+++ b/src/Utils/Tools/GetValidString.cpp
@@ -1,7 +1,6 @@
 #include "Utils/Tools/GetValidString.hpp"
 
-string getValidString(const string &prompt,
-                           const StringValidator validations) {
+string getValidString(const string &prompt, const StringValidator validations) {
   string str;
 
   while (true) {

--- a/src/Utils/Tools/IgnoreCin.cpp
+++ b/src/Utils/Tools/IgnoreCin.cpp
@@ -1,5 +1,3 @@
 #include "Utils/Tools/IgnoreCin.hpp"
 
-void ignoreCin() {
-  cin.ignore(numeric_limits<streamsize>::max(), '\n');
-}
+void ignoreCin() { cin.ignore(numeric_limits<streamsize>::max(), '\n'); }

--- a/src/Utils/Validation/ValidateEmptyRepository.cpp
+++ b/src/Utils/Validation/ValidateEmptyRepository.cpp
@@ -1,6 +1,6 @@
 #include "Utils/Validation/ValidateEmptyRepository.hpp"
 
 void ValidateEmptyRepository(size_t repositorySize) {
-	if (repositorySize == 0)
-		throw EmptyRepositoryException(EmptyRepositoryMessage());
+  if (repositorySize == 0)
+    throw EmptyRepositoryException(EmptyRepositoryMessage());
 }

--- a/src/Utils/Validation/ValidateIndex.cpp
+++ b/src/Utils/Validation/ValidateIndex.cpp
@@ -1,6 +1,6 @@
 #include "Utils/Validation/ValidateIndex.hpp"
 
 void ValidateIndex(int index, int repositorySize) {
-    if (index < 0 or index >= repositorySize)
-        throw InvalidIndexException(InvalidIndexMessage());
+  if (index < 0 or index >= repositorySize)
+    throw InvalidIndexException(InvalidIndexMessage());
 }

--- a/src/Utils/Validation/ValidateIndexes.cpp
+++ b/src/Utils/Validation/ValidateIndexes.cpp
@@ -1,11 +1,12 @@
 #include "Utils/Validation/ValidateIndexes.hpp"
 
-// The function who calls it GUARANTEES that the string only contains numbers separated by whitespaces
-void ValidateIndexes(const string& data, int repositorySize) {
-	istringstream iss(data);
-	int num;
+// The function who calls it GUARANTEES that the string only contains numbers
+// separated by whitespaces
+void ValidateIndexes(const string &data, int repositorySize) {
+  istringstream iss(data);
+  int num;
 
-	while (iss >> num) 
-		if (num < 0 or num >= repositorySize)
-			throw InvalidIndexStringException(InvalidIndexStringMessage());
+  while (iss >> num)
+    if (num < 0 or num >= repositorySize)
+      throw InvalidIndexStringException(InvalidIndexStringMessage());
 }

--- a/src/Utils/Validation/ValidateOnlyIntegers.cpp
+++ b/src/Utils/Validation/ValidateOnlyIntegers.cpp
@@ -1,18 +1,18 @@
 #include "Utils/Validation/ValidateOnlyIntegers.hpp"
 
-void ValidateOnlyIntegers(const std::string& str) {
-	istringstream iss(str);
-	string token;
+void ValidateOnlyIntegers(const std::string &str) {
+  istringstream iss(str);
+  string token;
 
-	while (iss >> token) {
-		for (size_t i = 0; i < token.size(); i++){
-			if (i == 0 and token[i] == '-' and token.size() > 1)
-                continue;
-            if (!isdigit(token[i])) 
-                throw InvalidNumberInputException(InvalidNumberInputMessage());
-		}
-	}
-
-	if (!iss.eof())
+  while (iss >> token) {
+    for (size_t i = 0; i < token.size(); i++) {
+      if (i == 0 and token[i] == '-' and token.size() > 1)
+        continue;
+      if (!isdigit(token[i]))
         throw InvalidNumberInputException(InvalidNumberInputMessage());
+    }
+  }
+
+  if (!iss.eof())
+    throw InvalidNumberInputException(InvalidNumberInputMessage());
 }

--- a/src/Utils/Validation/ValidateRepositoryNotEmpty.cpp
+++ b/src/Utils/Validation/ValidateRepositoryNotEmpty.cpp
@@ -1,5 +1,5 @@
 #include "Utils/Validation/ValidateRepositoryNotEmpty.hpp"
 
 void ValidateRepositoryNotEmpty(ConstRepository repositorySize) {
-	ValidateEmptyRepository(repositorySize.size());
+  ValidateEmptyRepository(repositorySize.size());
 }

--- a/test/CreateCommandTest.cpp
+++ b/test/CreateCommandTest.cpp
@@ -1,119 +1,119 @@
 #include "Commander/Commands/CreateCommand.hpp"
-#include "Commander/Contexts/CreateCommandContext.hpp"
 #include "../def/Repository.hpp"
+#include "Commander/Contexts/CreateCommandContext.hpp"
 #include "Set/Set.hpp"
 
 #include <gtest/gtest.h>
 #include <queue>
-#include <vector>
 #include <string>
+#include <vector>
 
 using std::queue;
-using std::vector;
 using std::string;
+using std::vector;
 
 // Helper to capture stdout from execute()
-static string captureExecute(CreateCommand& cmd, CreateCommandContext* ctx) {
-    testing::internal::CaptureStdout();
-    cmd.execute(ctx);
-    return testing::internal::GetCapturedStdout();
+static string captureExecute(CreateCommand &cmd, CreateCommandContext *ctx) {
+  testing::internal::CaptureStdout();
+  cmd.execute(ctx);
+  return testing::internal::GetCapturedStdout();
 }
 
 TEST(CreateCommandTest, ExecuteWithEmptyInitialData) {
-    vector<SetInfo> repo;
-    queue<int> data;  // empty
-    CreateCommandContext ctx(repo, data, "test-origin");
-    CreateCommand cmd("create", "desc");
+  vector<SetInfo> repo;
+  queue<int> data; // empty
+  CreateCommandContext ctx(repo, data, "test-origin");
+  CreateCommand cmd("create", "desc");
 
-    string output = captureExecute(cmd, &ctx);
+  string output = captureExecute(cmd, &ctx);
 
-    // Should have added one SetInfo at position 0
-    ASSERT_EQ(repo.size(), 1u);
-    EXPECT_EQ(repo[0].origin, "gerado por linha de comando");
-    // The stored Set* must not be null and must be empty
-    EXPECT_NE(repo[0].set, nullptr);
-    EXPECT_EQ(repo[0].set->size(), 0u);
+  // Should have added one SetInfo at position 0
+  ASSERT_EQ(repo.size(), 1u);
+  EXPECT_EQ(repo[0].origin, "gerado por linha de comando");
+  // The stored Set* must not be null and must be empty
+  EXPECT_NE(repo[0].set, nullptr);
+  EXPECT_EQ(repo[0].set->size(), 0u);
 
-    // Context's initialData should now be empty
-    EXPECT_TRUE(ctx.initialData.empty());
+  // Context's initialData should now be empty
+  EXPECT_TRUE(ctx.initialData.empty());
 
-    // Output message should mention position 0
-    EXPECT_EQ(output, "Conjunto adicionado com sucesso na posição 0\n");
+  // Output message should mention position 0
+  EXPECT_EQ(output, "Conjunto adicionado com sucesso na posição 0\n");
 }
 
 TEST(CreateCommandTest, ExecuteWithSomeInitialData) {
-    vector<SetInfo> repo;
-    queue<int> data;
-    data.push(10);
-    data.push(20);
-    data.push(10);  // duplicate to see if Set ignores it
+  vector<SetInfo> repo;
+  queue<int> data;
+  data.push(10);
+  data.push(20);
+  data.push(10); // duplicate to see if Set ignores it
 
-    CreateCommandContext ctx(repo, data, "cli");
-    CreateCommand cmd("create", "desc");
+  CreateCommandContext ctx(repo, data, "cli");
+  CreateCommand cmd("create", "desc");
 
-    string output = captureExecute(cmd, &ctx);
+  string output = captureExecute(cmd, &ctx);
 
-    // One new entry at position 0
-    ASSERT_EQ(repo.size(), 1u);
-    Set* result = repo[0].set;
-    ASSERT_NE(result, nullptr);
+  // One new entry at position 0
+  ASSERT_EQ(repo.size(), 1u);
+  Set *result = repo[0].set;
+  ASSERT_NE(result, nullptr);
 
-    // Should contain 10 and 20 only once each
-    EXPECT_TRUE(result->contains(10));
-    EXPECT_TRUE(result->contains(20));
-    EXPECT_EQ(result->size(), 2u);
+  // Should contain 10 and 20 only once each
+  EXPECT_TRUE(result->contains(10));
+  EXPECT_TRUE(result->contains(20));
+  EXPECT_EQ(result->size(), 2u);
 
-    // Context queue emptied
-    EXPECT_TRUE(ctx.initialData.empty());
+  // Context queue emptied
+  EXPECT_TRUE(ctx.initialData.empty());
 
-    // Output mentions correct position
-    EXPECT_EQ(output, "Conjunto adicionado com sucesso na posição 0\n");
+  // Output mentions correct position
+  EXPECT_EQ(output, "Conjunto adicionado com sucesso na posição 0\n");
 }
 
 TEST(CreateCommandTest, ExecuteAppendsToExistingRepository) {
-    vector<SetInfo> repo;
-    // Pre-populate repo with two dummy sets
-    repo.emplace_back(new Set(), "old1");
-    repo.emplace_back(new Set(), "old2");
+  vector<SetInfo> repo;
+  // Pre-populate repo with two dummy sets
+  repo.emplace_back(new Set(), "old1");
+  repo.emplace_back(new Set(), "old2");
 
-    queue<int> data;
-    data.push(5);
+  queue<int> data;
+  data.push(5);
 
-    CreateCommandContext ctx(repo, data, "cli2");
-    CreateCommand cmd("create", "desc2");
+  CreateCommandContext ctx(repo, data, "cli2");
+  CreateCommand cmd("create", "desc2");
 
-    string output = captureExecute(cmd, &ctx);
+  string output = captureExecute(cmd, &ctx);
 
-    // Should now have size 3, new at index 2
-    ASSERT_EQ(repo.size(), 3u);
-    EXPECT_EQ(repo[2].origin, "gerado por linha de comando");
-    EXPECT_TRUE(repo[2].set->contains(5));
-    EXPECT_EQ(output, "Conjunto adicionado com sucesso na posição 2\n");
+  // Should now have size 3, new at index 2
+  ASSERT_EQ(repo.size(), 3u);
+  EXPECT_EQ(repo[2].origin, "gerado por linha de comando");
+  EXPECT_TRUE(repo[2].set->contains(5));
+  EXPECT_EQ(output, "Conjunto adicionado com sucesso na posição 2\n");
 }
 
 TEST(CreateCommandTest, MultipleExecuteCallsAreIndependent) {
-    vector<SetInfo> repo;
-    queue<int> data1;
-    data1.push(1);
-    CreateCommandContext ctx1(repo, data1, "o1");
+  vector<SetInfo> repo;
+  queue<int> data1;
+  data1.push(1);
+  CreateCommandContext ctx1(repo, data1, "o1");
 
-    CreateCommand cmd("create", "desc");
+  CreateCommand cmd("create", "desc");
 
-    // First execution
-    string out1 = captureExecute(cmd, &ctx1);
-    EXPECT_EQ(repo.size(), 1u);
-    EXPECT_EQ(out1, "Conjunto adicionado com sucesso na posição 0\n");
+  // First execution
+  string out1 = captureExecute(cmd, &ctx1);
+  EXPECT_EQ(repo.size(), 1u);
+  EXPECT_EQ(out1, "Conjunto adicionado com sucesso na posição 0\n");
 
-    // Prepare a second context with different data
-    queue<int> data2;
-    data2.push(2);
-    data2.push(3);
-    CreateCommandContext ctx2(repo, data2, "o2");
+  // Prepare a second context with different data
+  queue<int> data2;
+  data2.push(2);
+  data2.push(3);
+  CreateCommandContext ctx2(repo, data2, "o2");
 
-    // Second execution appends to position 1
-    string out2 = captureExecute(cmd, &ctx2);
-    EXPECT_EQ(repo.size(), 2u);
-    EXPECT_TRUE(repo[1].set->contains(2));
-    EXPECT_TRUE(repo[1].set->contains(3));
-    EXPECT_EQ(out2, "Conjunto adicionado com sucesso na posição 1\n");
+  // Second execution appends to position 1
+  string out2 = captureExecute(cmd, &ctx2);
+  EXPECT_EQ(repo.size(), 2u);
+  EXPECT_TRUE(repo[1].set->contains(2));
+  EXPECT_TRUE(repo[1].set->contains(3));
+  EXPECT_EQ(out2, "Conjunto adicionado com sucesso na posição 1\n");
 }

--- a/test/GetValidNumberTest.cpp
+++ b/test/GetValidNumberTest.cpp
@@ -1,51 +1,50 @@
-#include <gtest/gtest.h>
-#include <sstream>
-#include <iostream>
 #include <functional>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
 #include <vector>
 
-#include "Utils/Tools/GetValidNumber.hpp"
 #include "Exceptions/InvalidArgumentException.hpp"
 #include "Messages/InvalidArgumentForNumberMessage.hpp"
+#include "Utils/Tools/GetValidNumber.hpp"
 
-using std::stringstream;
-using std::string;
 using std::cin;
+using std::string;
+using std::stringstream;
 
 // Helper to simulate user input for testing purposes
 static void simulateInput(stringstream &ss, const string &input) {
-    ss.str(input);
-    ss.clear();
-    cin.rdbuf(ss.rdbuf());
+  ss.str(input);
+  ss.clear();
+  cin.rdbuf(ss.rdbuf());
 }
 
 // A simple validator that ensures the number is positive
 void positiveValidator(int number) {
-    if (number <= 0) {
-        throw InvalidArgumentException(InvalidArgumentForNumberMessage());
-    }
+  if (number <= 0) {
+    throw InvalidArgumentException(InvalidArgumentForNumberMessage());
+  }
 }
 
 // A simple validator that ensures the number is less than 100
 void lessThan100Validator(int number) {
-    if (number >= 100) {
-        throw InvalidArgumentException(InvalidArgumentForNumberMessage());
-    }
+  if (number >= 100) {
+    throw InvalidArgumentException(InvalidArgumentForNumberMessage());
+  }
 }
 
 TEST(GetValidNumberTest, ValidNumberWithOneValidator) {
-    // Test for valid positive number input
-    stringstream input;
-    input.str("42\n");  // Simulate input from the user
-    simulateInput(input, "42");
-    
-    IntValidator validators = positiveValidator;
-    
-    int result = getValidNumber("Enter a positive number: ", validators);
+  // Test for valid positive number input
+  stringstream input;
+  input.str("42\n"); // Simulate input from the user
+  simulateInput(input, "42");
 
-    EXPECT_EQ(result, 42);
+  IntValidator validators = positiveValidator;
+
+  int result = getValidNumber("Enter a positive number: ", validators);
+
+  EXPECT_EQ(result, 42);
 }
-
 
 TEST(GetValidNumberTest, InvalidThenValid) {
   // Simula: primeiro -5 (inválido), depois 42 (válido)
@@ -59,39 +58,51 @@ TEST(GetValidNumberTest, InvalidThenValid) {
 }
 
 TEST(GetValidNumberTest, ValidNumberWithMultipleValidators) {
-    // Test for valid number that satisfies multiple validators
-    stringstream input;
-    input.str("42\n");  // Simulate input from the user
-    simulateInput(input, "42");
+  // Test for valid number that satisfies multiple validators
+  stringstream input;
+  input.str("42\n"); // Simulate input from the user
+  simulateInput(input, "42");
 
-    IntValidator validators = [](int number){ positiveValidator(number); lessThan100Validator(number); };
+  IntValidator validators = [](int number) {
+    positiveValidator(number);
+    lessThan100Validator(number);
+  };
 
-    int result = getValidNumber("Enter a positive number less than 100: ", validators);
+  int result =
+      getValidNumber("Enter a positive number less than 100: ", validators);
 
-    EXPECT_EQ(result, 42);
+  EXPECT_EQ(result, 42);
 }
 
 TEST(GetValidNumberTest, InvalidNumberWithMultipleValidators) {
-    // Test for invalid number that fails the "less than 100" validator
-    stringstream input;
-    input.str("150\n42\n");  // Simulate invalid input followed by valid one
-    simulateInput(input, "150\n42");
+  // Test for invalid number that fails the "less than 100" validator
+  stringstream input;
+  input.str("150\n42\n"); // Simulate invalid input followed by valid one
+  simulateInput(input, "150\n42");
 
-    IntValidator validators = [](int number){ positiveValidator(number); lessThan100Validator(number); };
+  IntValidator validators = [](int number) {
+    positiveValidator(number);
+    lessThan100Validator(number);
+  };
 
-    int result = getValidNumber("Enter a positive number less than 100: ", validators);
-    EXPECT_EQ(result, 42);
+  int result =
+      getValidNumber("Enter a positive number less than 100: ", validators);
+  EXPECT_EQ(result, 42);
 }
 
 TEST(GetValidNumberTest, InputValidationWithMultipleFailures) {
-    // Test when multiple invalid inputs are provided
-    stringstream input;
-    input.str("-1\n0\n105\n42\n");  // Invalid inputs followed by valid one
-    simulateInput(input, "-1\n0\n105\n42");
+  // Test when multiple invalid inputs are provided
+  stringstream input;
+  input.str("-1\n0\n105\n42\n"); // Invalid inputs followed by valid one
+  simulateInput(input, "-1\n0\n105\n42");
 
-    IntValidator validators = [](int number){ positiveValidator(number); lessThan100Validator(number); };
+  IntValidator validators = [](int number) {
+    positiveValidator(number);
+    lessThan100Validator(number);
+  };
 
-    int result = getValidNumber("Enter a positive number less than 100: ", validators);
+  int result =
+      getValidNumber("Enter a positive number less than 100: ", validators);
 
-    EXPECT_EQ(result, 42);
+  EXPECT_EQ(result, 42);
 }

--- a/test/GetValidStringTest.cpp
+++ b/test/GetValidStringTest.cpp
@@ -1,142 +1,143 @@
-#include <gtest/gtest.h>
-#include <sstream>
-#include <iostream>
 #include <functional>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
 #include <string>
 
 #include "Utils/Tools/GetValidString.hpp"
 
-using std::stringstream;
-using std::string;
 using std::cin;
 using std::invalid_argument;
+using std::string;
+using std::stringstream;
 
 // Helper to simulate user input for testing purposes
 static void simulateInput(stringstream &ss, const string &input) {
-    ss.str(input);
-    ss.clear();
-    cin.rdbuf(ss.rdbuf());
+  ss.str(input);
+  ss.clear();
+  cin.rdbuf(ss.rdbuf());
 }
 
 // Simple validators
-void nonEmptyValidator(const string& str) {
-    if (str.empty()) {
-        throw invalid_argument("Input cannot be empty");
-    }
+void nonEmptyValidator(const string &str) {
+  if (str.empty()) {
+    throw invalid_argument("Input cannot be empty");
+  }
 }
 
-void startsWithCapitalValidator(const string& str) {
-    if (!str.empty() && !isupper(str[0])) {
-        throw invalid_argument("Input must start with a capital letter");
-    }
+void startsWithCapitalValidator(const string &str) {
+  if (!str.empty() && !isupper(str[0])) {
+    throw invalid_argument("Input must start with a capital letter");
+  }
 }
 
 TEST(GetValidStringTest, ValidStringWithOneValidator) {
-    // Test for valid string input
-    stringstream input;
-    input.str("Hello World\n");  // Simulate input from the user
-    simulateInput(input, "Hello World");
+  // Test for valid string input
+  stringstream input;
+  input.str("Hello World\n"); // Simulate input from the user
+  simulateInput(input, "Hello World");
 
-    auto validators = [](const string& str) {
-        nonEmptyValidator(str);
-    };
-    
-    string result = getValidString("Enter a string: ", validators);
+  auto validators = [](const string &str) { nonEmptyValidator(str); };
 
-    EXPECT_EQ(result, "Hello World");
+  string result = getValidString("Enter a string: ", validators);
+
+  EXPECT_EQ(result, "Hello World");
 }
 
 TEST(GetValidStringTest, InvalidStringWithOneValidator) {
-    // Test for invalid empty string input
-    stringstream input;
-    input.str("\nHello World\n");  // Simulate invalid input followed by valid one
-    simulateInput(input, "\nHello World");
+  // Test for invalid empty string input
+  stringstream input;
+  input.str("\nHello World\n"); // Simulate invalid input followed by valid one
+  simulateInput(input, "\nHello World");
 
-    auto validators = [](const string& str) {
-        nonEmptyValidator(str);
-    };
-    
-    string result = getValidString("Enter a non-empty string: ", validators);
+  auto validators = [](const string &str) { nonEmptyValidator(str); };
 
-    EXPECT_EQ(result, "Hello World");
+  string result = getValidString("Enter a non-empty string: ", validators);
+
+  EXPECT_EQ(result, "Hello World");
 }
 
 TEST(GetValidStringTest, ValidStringWithMultipleValidators) {
-    // Test for valid string that satisfies multiple validators
-    stringstream input;
-    input.str("Hello World\n");  // Simulate input from the user
-    simulateInput(input, "Hello World");
+  // Test for valid string that satisfies multiple validators
+  stringstream input;
+  input.str("Hello World\n"); // Simulate input from the user
+  simulateInput(input, "Hello World");
 
-    auto validators = [](const string& str) {
-        nonEmptyValidator(str);
-        startsWithCapitalValidator(str);
-    };
+  auto validators = [](const string &str) {
+    nonEmptyValidator(str);
+    startsWithCapitalValidator(str);
+  };
 
-    string result = getValidString("Enter a valid string: ", validators);
+  string result = getValidString("Enter a valid string: ", validators);
 
-    EXPECT_EQ(result, "Hello World");
+  EXPECT_EQ(result, "Hello World");
 }
 
 TEST(GetValidStringTest, InvalidStringWithMultipleValidators) {
-    // Test for invalid string input that fails startsWithCapitalValidator
-    stringstream input;
-    input.str("hello world\nHello World\n");  // Simulate invalid input followed by valid one
-    simulateInput(input, "hello world\nHello World");
+  // Test for invalid string input that fails startsWithCapitalValidator
+  stringstream input;
+  input.str("hello world\nHello World\n"); // Simulate invalid input followed by
+                                           // valid one
+  simulateInput(input, "hello world\nHello World");
 
-    auto validators = [](const string& str) {
-        nonEmptyValidator(str);
-        startsWithCapitalValidator(str);
-    };
+  auto validators = [](const string &str) {
+    nonEmptyValidator(str);
+    startsWithCapitalValidator(str);
+  };
 
-    string result = getValidString("Enter a string starting with a capital letter: ", validators);
+  string result = getValidString(
+      "Enter a string starting with a capital letter: ", validators);
 
-    EXPECT_EQ(result, "Hello World");
+  EXPECT_EQ(result, "Hello World");
 }
 
 TEST(GetValidStringTest, InvalidStringWithMultipleValidatorsFailsFirst) {
-    // Test for invalid string input that fails the nonEmptyValidator
-    stringstream input;
-    input.str("\nhello world\nHello World\n");  // Simulate invalid input followed by valid one
-    simulateInput(input, "\nhello world\nHello World");
+  // Test for invalid string input that fails the nonEmptyValidator
+  stringstream input;
+  input.str("\nhello world\nHello World\n"); // Simulate invalid input followed
+                                             // by valid one
+  simulateInput(input, "\nhello world\nHello World");
 
-    auto validators = [](const string& str) {
-        nonEmptyValidator(str);
-        startsWithCapitalValidator(str);
-    };
+  auto validators = [](const string &str) {
+    nonEmptyValidator(str);
+    startsWithCapitalValidator(str);
+  };
 
-    string result = getValidString("Enter a non-empty string starting with a capital letter: ", validators);
+  string result = getValidString(
+      "Enter a non-empty string starting with a capital letter: ", validators);
 
-    EXPECT_EQ(result, "Hello World");
+  EXPECT_EQ(result, "Hello World");
 }
 
 TEST(GetValidStringTest, InputValidationWithMultipleFailures) {
-    // Test when multiple invalid inputs are provided
-    stringstream input;
-    input.str("\n\nhello\nHello World\n");  // Invalid inputs followed by valid one
-    simulateInput(input, "\n\nhello\nHello World");
+  // Test when multiple invalid inputs are provided
+  stringstream input;
+  input.str("\n\nhello\nHello World\n"); // Invalid inputs followed by valid one
+  simulateInput(input, "\n\nhello\nHello World");
 
-    auto validators = [](const string& str) {
-        nonEmptyValidator(str);
-        startsWithCapitalValidator(str);
-    };
+  auto validators = [](const string &str) {
+    nonEmptyValidator(str);
+    startsWithCapitalValidator(str);
+  };
 
-    string result = getValidString("Enter a valid string: ", validators);
+  string result = getValidString("Enter a valid string: ", validators);
 
-    EXPECT_EQ(result, "Hello World");
+  EXPECT_EQ(result, "Hello World");
 }
 
 TEST(GetValidStringTest, DoesNotEnterInfiniteLoop) {
-    // Test when there is no infinite loop and returns valid string after multiple invalid attempts
-    stringstream input;
-    input.str("\n\nhello\nHello World\n");  // Invalid inputs followed by valid one
-    simulateInput(input, "\n\nhello\nHello World");
+  // Test when there is no infinite loop and returns valid string after multiple
+  // invalid attempts
+  stringstream input;
+  input.str("\n\nhello\nHello World\n"); // Invalid inputs followed by valid one
+  simulateInput(input, "\n\nhello\nHello World");
 
-    auto validators = [](const string& str) {
-        nonEmptyValidator(str);
-        startsWithCapitalValidator(str);
-    };
+  auto validators = [](const string &str) {
+    nonEmptyValidator(str);
+    startsWithCapitalValidator(str);
+  };
 
-    string result = getValidString("Enter a valid string: ", validators);
+  string result = getValidString("Enter a valid string: ", validators);
 
-    EXPECT_EQ(result, "Hello World");
+  EXPECT_EQ(result, "Hello World");
 }

--- a/test/SetTest.cpp
+++ b/test/SetTest.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <cmath>
+#include <gtest/gtest.h>
 
 #include "Set/Set.hpp"
 
@@ -7,170 +7,167 @@ using namespace std;
 
 class SetTest : public ::testing::Test {
 protected:
-	Set set;
+  Set set;
 };
 
-TEST_F(SetTest, ContainsOnEmptys) {
-	EXPECT_FALSE(set.contains(10));
-}
+TEST_F(SetTest, ContainsOnEmptys) { EXPECT_FALSE(set.contains(10)); }
 
 TEST_F(SetTest, ContainsAfterSingleInsert) {
-    set.insert(10);
-    EXPECT_TRUE(set.contains(10));
-    EXPECT_FALSE(set.contains(20));
+  set.insert(10);
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_FALSE(set.contains(20));
 }
 
 TEST_F(SetTest, ContainsMultipleInserts) {
-    set.insert(10);
-    set.insert(20);
-    set.insert(30);
-    
-    EXPECT_TRUE(set.contains(10));
-    EXPECT_TRUE(set.contains(20));
-    EXPECT_TRUE(set.contains(30));
-    EXPECT_FALSE(set.contains(40));
+  set.insert(10);
+  set.insert(20);
+  set.insert(30);
+
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_TRUE(set.contains(20));
+  EXPECT_TRUE(set.contains(30));
+  EXPECT_FALSE(set.contains(40));
 }
 
 TEST_F(SetTest, ContainsWithDuplicateInsertions) {
-    set.insert(10);
-    set.insert(10);
-    EXPECT_TRUE(set.contains(10));
-    EXPECT_FALSE(set.contains(20));
+  set.insert(10);
+  set.insert(10);
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_FALSE(set.contains(20));
 }
 
 TEST_F(SetTest, ContainsAfterRotationLL) {
-    set.insert(10);
-    set.insert(20);
-    set.insert(30); // Causes an LL rotation
-    EXPECT_TRUE(set.contains(10));
-    EXPECT_TRUE(set.contains(20));
-    EXPECT_TRUE(set.contains(30));
+  set.insert(10);
+  set.insert(20);
+  set.insert(30); // Causes an LL rotation
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_TRUE(set.contains(20));
+  EXPECT_TRUE(set.contains(30));
 }
 
 TEST_F(SetTest, ContainsAfterRotationRR) {
-    set.insert(30);
-    set.insert(20);
-    set.insert(10); // Causes an RR rotation
-    EXPECT_TRUE(set.contains(10));
-    EXPECT_TRUE(set.contains(20));
-    EXPECT_TRUE(set.contains(30));
+  set.insert(30);
+  set.insert(20);
+  set.insert(10); // Causes an RR rotation
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_TRUE(set.contains(20));
+  EXPECT_TRUE(set.contains(30));
 }
 
-
 TEST_F(SetTest, ContainsAfterRotationLR) {
-    set.insert(30);
-    set.insert(10);
-    set.insert(20); // Causes an LR rotation
-    EXPECT_TRUE(set.contains(10));
-    EXPECT_TRUE(set.contains(20));
-    EXPECT_TRUE(set.contains(30));
+  set.insert(30);
+  set.insert(10);
+  set.insert(20); // Causes an LR rotation
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_TRUE(set.contains(20));
+  EXPECT_TRUE(set.contains(30));
 }
 
 TEST_F(SetTest, ContainsAfterRotationRL) {
-    set.insert(10);
-    set.insert(30);
-    set.insert(20); // Causes an RL rotation
-    EXPECT_TRUE(set.contains(10));
-    EXPECT_TRUE(set.contains(20));
-    EXPECT_TRUE(set.contains(30));
+  set.insert(10);
+  set.insert(30);
+  set.insert(20); // Causes an RL rotation
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_TRUE(set.contains(20));
+  EXPECT_TRUE(set.contains(30));
 }
 
 TEST_F(SetTest, ContainsWithNegativeValues) {
-    set.insert(-10);
-    set.insert(-20);
-    EXPECT_TRUE(set.contains(-10));
-    EXPECT_TRUE(set.contains(-20));
-    EXPECT_FALSE(set.contains(-30));
+  set.insert(-10);
+  set.insert(-20);
+  EXPECT_TRUE(set.contains(-10));
+  EXPECT_TRUE(set.contains(-20));
+  EXPECT_FALSE(set.contains(-30));
 }
 
 TEST_F(SetTest, Insertion) {
-	set.insert(1);
-	EXPECT_EQ(set.getRoot()->key, 1);
+  set.insert(1);
+  EXPECT_EQ(set.getRoot()->key, 1);
 }
 
 TEST_F(SetTest, TestGetBalance) {
-	set.insert(1);
-	ASSERT_EQ(set.getBalanceForTest(set.getRoot()), 0);
+  set.insert(1);
+  ASSERT_EQ(set.getBalanceForTest(set.getRoot()), 0);
 }
 
 TEST_F(SetTest, InsertDuplicate) {
-	set.insert(5);
-	set.insert(5);
-	EXPECT_EQ(set.size(), 1);
+  set.insert(5);
+  set.insert(5);
+  EXPECT_EQ(set.size(), 1);
 }
 
 TEST_F(SetTest, Emptys) {
-    EXPECT_EQ(set.size(), 0);
-    EXPECT_EQ(set.getHeight(), 0);
-    EXPECT_FALSE(set.contains(42));
+  EXPECT_EQ(set.size(), 0);
+  EXPECT_EQ(set.getHeight(), 0);
+  EXPECT_FALSE(set.contains(42));
 }
 
 TEST_F(SetTest, InsertSingleElement) {
-    set.insert(10);
-    EXPECT_EQ(set.size(), 1);
-    set.contains(10);
-    EXPECT_EQ(set.getHeight(), 1);
+  set.insert(10);
+  EXPECT_EQ(set.size(), 1);
+  set.contains(10);
+  EXPECT_EQ(set.getHeight(), 1);
 }
 
 TEST_F(SetTest, HeightBoundAfterMultipleInsert) {
-    const int n = 15;
-    for (int i = 0; i < n; ++i) {
-        set.insert(i);
-    }
-    int h = set.getHeight();
-    int bound = static_cast<int>(floor(log2(n))) + 1;
-    EXPECT_LE(h, bound);
+  const int n = 15;
+  for (int i = 0; i < n; ++i) {
+    set.insert(i);
+  }
+  int h = set.getHeight();
+  int bound = static_cast<int>(floor(log2(n))) + 1;
+  EXPECT_LE(h, bound);
 }
 
-TEST_F(SetTest, SwapEmptyTrees) { 
-	Set otherSet; 
-	set.swap(otherSet); 
-	EXPECT_TRUE(set.empty()); 
-	EXPECT_TRUE(otherSet.empty()); 
+TEST_F(SetTest, SwapEmptyTrees) {
+  Set otherSet;
+  set.swap(otherSet);
+  EXPECT_TRUE(set.empty());
+  EXPECT_TRUE(otherSet.empty());
 }
 
 TEST_F(SetTest, SwapWithEmptyTree) {
-	Set otherSet;
-	otherSet.insert(10);
-	set.swap(otherSet);
-	EXPECT_TRUE(set.contains(10));
-	EXPECT_FALSE(otherSet.contains(10));
+  Set otherSet;
+  otherSet.insert(10);
+  set.swap(otherSet);
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_FALSE(otherSet.contains(10));
 }
 
-TEST_F(SetTest, SwapNonEmptyTrees) { 
-	set.insert(10); 
-	set.insert(20); 
-	set.insert(30); 
+TEST_F(SetTest, SwapNonEmptyTrees) {
+  set.insert(10);
+  set.insert(20);
+  set.insert(30);
 
-	Set otherSet; 
-	otherSet.insert(40); 
-	otherSet.insert(50); 
-	set.swap(otherSet); 
-	EXPECT_TRUE(set.contains(40)); 
-	EXPECT_TRUE(set.contains(50)); 
-	EXPECT_FALSE(set.contains(10)); 
-	EXPECT_FALSE(set.contains(20)); 
-	EXPECT_FALSE(set.contains(30));
+  Set otherSet;
+  otherSet.insert(40);
+  otherSet.insert(50);
+  set.swap(otherSet);
+  EXPECT_TRUE(set.contains(40));
+  EXPECT_TRUE(set.contains(50));
+  EXPECT_FALSE(set.contains(10));
+  EXPECT_FALSE(set.contains(20));
+  EXPECT_FALSE(set.contains(30));
 }
 
 TEST_F(SetTest, SwapWithItself) {
-	set.insert(10);
-	set.insert(20);
-	set.swap(set);
-	EXPECT_TRUE(set.contains(10));
-	EXPECT_TRUE(set.contains(20));
+  set.insert(10);
+  set.insert(20);
+  set.swap(set);
+  EXPECT_TRUE(set.contains(10));
+  EXPECT_TRUE(set.contains(20));
 }
 
 TEST_F(SetTest, AfterSwapOriginalEmpty) {
-	Set otherSet; 
-	set.insert(100); 
-	set.swap(otherSet); 
-	EXPECT_TRUE(set.empty()); 
-	EXPECT_FALSE(otherSet.empty());
+  Set otherSet;
+  set.insert(100);
+  set.swap(otherSet);
+  EXPECT_TRUE(set.empty());
+  EXPECT_FALSE(otherSet.empty());
 }
 
 int main(int argc, char **argv) {
-	::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
 
-	return RUN_ALL_TESTS();
+  return RUN_ALL_TESTS();
 }

--- a/test/TrimTest.cpp
+++ b/test/TrimTest.cpp
@@ -3,71 +3,73 @@
 #include "Utils/Tools/Trim.hpp"
 
 TEST(TrimTest, TrimEmptyString) {
-    // Testa uma string vazia
-    EXPECT_EQ(trim(""), "");
+  // Testa uma string vazia
+  EXPECT_EQ(trim(""), "");
 }
 
 TEST(TrimTest, TrimStringWithOnlySpaces) {
-    // Testa uma string que contém apenas espaços
-    EXPECT_EQ(trim("     "), "");
+  // Testa uma string que contém apenas espaços
+  EXPECT_EQ(trim("     "), "");
 }
 
 TEST(TrimTest, TrimStringWithLeadingSpaces) {
-    // Testa uma string com espaços no início
-    EXPECT_EQ(trim("   Hello World"), "Hello World");
+  // Testa uma string com espaços no início
+  EXPECT_EQ(trim("   Hello World"), "Hello World");
 }
 
 TEST(TrimTest, TrimStringWithTrailingSpaces) {
-    // Testa uma string com espaços no final
-    EXPECT_EQ(trim("Hello World   "), "Hello World");
+  // Testa uma string com espaços no final
+  EXPECT_EQ(trim("Hello World   "), "Hello World");
 }
 
 TEST(TrimTest, TrimStringWithLeadingAndTrailingSpaces) {
-    // Testa uma string com espaços no início e no final
-    EXPECT_EQ(trim("   Hello World   "), "Hello World");
+  // Testa uma string com espaços no início e no final
+  EXPECT_EQ(trim("   Hello World   "), "Hello World");
 }
 
 TEST(TrimTest, TrimStringWithNoSpaces) {
-    // Testa uma string sem espaços
-    EXPECT_EQ(trim("HelloWorld"), "HelloWorld");
+  // Testa uma string sem espaços
+  EXPECT_EQ(trim("HelloWorld"), "HelloWorld");
 }
 
 TEST(TrimTest, TrimStringWithSpacesAroundTabsAndNewlines) {
-    // Testa uma string com espaços, tabs e quebras de linha
-    EXPECT_EQ(trim("\t  \n  Hello\n\t "), "Hello");
+  // Testa uma string com espaços, tabs e quebras de linha
+  EXPECT_EQ(trim("\t  \n  Hello\n\t "), "Hello");
 }
 
 TEST(TrimTest, TrimStringWithSpacesOnlyAtTheEdges) {
-    // Testa string com espaços somente nas extremidades
-    EXPECT_EQ(trim("   "), "");
+  // Testa string com espaços somente nas extremidades
+  EXPECT_EQ(trim("   "), "");
 }
 
 TEST(TrimTest, TrimStringWithMultipleSpacesInTheMiddle) {
-    // Testa string com múltiplos espaços no meio
-    EXPECT_EQ(trim("   Hello    World   "), "Hello World");
+  // Testa string com múltiplos espaços no meio
+  EXPECT_EQ(trim("   Hello    World   "), "Hello World");
 }
 
 TEST(TrimTest, TrimStringWithSingleCharacter) {
-    // Testa uma string com um único caractere
-    EXPECT_EQ(trim(" A "), "A");
+  // Testa uma string com um único caractere
+  EXPECT_EQ(trim(" A "), "A");
 }
 
 TEST(TrimTest, TrimStringWithTabsOnly) {
-    // Testa uma string com apenas tabs no início e final
-    EXPECT_EQ(trim("\t\tHello\t"), "Hello");
+  // Testa uma string com apenas tabs no início e final
+  EXPECT_EQ(trim("\t\tHello\t"), "Hello");
 }
 
 TEST(TrimTest, TrimStringWithCarriageReturn) {
-    // Testa uma string com retorno de carro no início e final
-    EXPECT_EQ(trim("\rHello World\r"), "Hello World");
+  // Testa uma string com retorno de carro no início e final
+  EXPECT_EQ(trim("\rHello World\r"), "Hello World");
 }
 
 TEST(TrimTest, TrimStringWithMixedWhitespace) {
-    // Testa string com caracteres de espaços misturados (espaços, tabs, novas linhas)
-    EXPECT_EQ(trim("\t \n  Hello World  \r "), "Hello World");
+  // Testa string com caracteres de espaços misturados (espaços, tabs, novas
+  // linhas)
+  EXPECT_EQ(trim("\t \n  Hello World  \r "), "Hello World");
 }
 
 TEST(TrimTest, TrimStringContainingNonWhitespaceCharacters) {
-    // Testa se o comportamento está correto quando a string contém outros caracteres não espaço
-    EXPECT_EQ(trim(" \t Test 123 \n "), "Test 123");
+  // Testa se o comportamento está correto quando a string contém outros
+  // caracteres não espaço
+  EXPECT_EQ(trim(" \t Test 123 \n "), "Test 123");
 }

--- a/test/ValidateEmptyRepositoryTest.cpp
+++ b/test/ValidateEmptyRepositoryTest.cpp
@@ -4,23 +4,24 @@
 #include "Utils/Validation/ValidateEmptyRepository.hpp"
 
 TEST(ValidateEmptyRepositoryTest, DoesNotThrowWhenRepositoryNotEmpty) {
-    // Quando o repositório tem 1 ou mais elementos, não deve lançar exceção
-    EXPECT_NO_THROW(ValidateEmptyRepository(1));
-    EXPECT_NO_THROW(ValidateEmptyRepository(5));
-    EXPECT_NO_THROW(ValidateEmptyRepository(1000));
+  // Quando o repositório tem 1 ou mais elementos, não deve lançar exceção
+  EXPECT_NO_THROW(ValidateEmptyRepository(1));
+  EXPECT_NO_THROW(ValidateEmptyRepository(5));
+  EXPECT_NO_THROW(ValidateEmptyRepository(1000));
 }
 
 TEST(ValidateEmptyRepositoryTest, ThrowsWhenRepositoryIsEmpty) {
-    // Quando o repositório é vazio (0 elementos), deve lançar exceção
-    EXPECT_THROW(ValidateEmptyRepository(0), EmptyRepositoryException);
+  // Quando o repositório é vazio (0 elementos), deve lançar exceção
+  EXPECT_THROW(ValidateEmptyRepository(0), EmptyRepositoryException);
 }
 
 TEST(ValidateEmptyRepositoryTest, CorrectExceptionIsThrown) {
-    // Testar se a exceção correta é lançada e com a mensagem correta
-    try {
-        ValidateEmptyRepository(0);
-        FAIL() << "Expected EmptyRepositoryException to be thrown";
-    } catch (const EmptyRepositoryException& e) {
-        EXPECT_STREQ(e.what(), "Nao foi possivel realizar a operacao. Nenhum conjunto foi criado no sistema");
-    } 
+  // Testar se a exceção correta é lançada e com a mensagem correta
+  try {
+    ValidateEmptyRepository(0);
+    FAIL() << "Expected EmptyRepositoryException to be thrown";
+  } catch (const EmptyRepositoryException &e) {
+    EXPECT_STREQ(e.what(), "Nao foi possivel realizar a operacao. Nenhum "
+                           "conjunto foi criado no sistema");
+  }
 }

--- a/test/ValidateIndexTest.cpp
+++ b/test/ValidateIndexTest.cpp
@@ -1,42 +1,47 @@
 #include <gtest/gtest.h>
 #include <stdexcept>
 
-#include "Utils/Validation/ValidateIndex.hpp"
 #include "Exceptions/InvalidIndexException.hpp"
 #include "Messages/InvalidIndexMessage.hpp"
+#include "Utils/Validation/ValidateIndex.hpp"
 
 TEST(ValidateIndexTest, DoesNotThrowWhenIndexIsValid) {
-    // Índices válidos não devem lançar exceção
-    EXPECT_NO_THROW(ValidateIndex(0, 5));  // primeiro elemento
-    EXPECT_NO_THROW(ValidateIndex(2, 5));  // elemento do meio
-    EXPECT_NO_THROW(ValidateIndex(4, 5));  // último elemento
+  // Índices válidos não devem lançar exceção
+  EXPECT_NO_THROW(ValidateIndex(0, 5)); // primeiro elemento
+  EXPECT_NO_THROW(ValidateIndex(2, 5)); // elemento do meio
+  EXPECT_NO_THROW(ValidateIndex(4, 5)); // último elemento
 }
 
 TEST(ValidateIndexTest, ThrowsWhenIndexIsEqualToRepositorySize) {
-    // Índice igual ao tamanho do repositório é inválido
-    EXPECT_THROW(ValidateIndex(5, 5), InvalidIndexException);
+  // Índice igual ao tamanho do repositório é inválido
+  EXPECT_THROW(ValidateIndex(5, 5), InvalidIndexException);
 }
 
 TEST(ValidateIndexTest, ThrowsWhenIndexIsGreaterThanRepositorySize) {
-    // Índice maior que o tamanho também é inválido
-    EXPECT_THROW(ValidateIndex(6, 5), InvalidIndexException);
-    EXPECT_THROW(ValidateIndex(100, 5), InvalidIndexException);
+  // Índice maior que o tamanho também é inválido
+  EXPECT_THROW(ValidateIndex(6, 5), InvalidIndexException);
+  EXPECT_THROW(ValidateIndex(100, 5), InvalidIndexException);
 }
 
 TEST(ValidateIndexTest, ThrowsWhenRepositoryIsEmpty) {
-    // Em um repositório vazio, qualquer índice é inválido
-    EXPECT_THROW(ValidateIndex(0, 0), InvalidIndexException);
-    EXPECT_THROW(ValidateIndex(1, 0), InvalidIndexException);
+  // Em um repositório vazio, qualquer índice é inválido
+  EXPECT_THROW(ValidateIndex(0, 0), InvalidIndexException);
+  EXPECT_THROW(ValidateIndex(1, 0), InvalidIndexException);
 }
 
 TEST(ValidateIndexTest, CorrectExceptionIsThrown) {
-    // Verifica se a exceção correta e a mensagem são as certas
-    try {
-        ValidateIndex(5, 5);
-        FAIL() << "Expected InvalidIndexException to be thrown";
-    } catch (const InvalidIndexException& e) {
-        EXPECT_STREQ(e.what(), "Hum... esse número não corresponde a nenhum conjunto. Poderia verificar qual o índice correto?");  // Ajuste se a mensagem for diferente
-    } catch (...) {
-        FAIL() << "Expected InvalidIndexException, but caught a different exception";
-    }
+  // Verifica se a exceção correta e a mensagem são as certas
+  try {
+    ValidateIndex(5, 5);
+    FAIL() << "Expected InvalidIndexException to be thrown";
+  } catch (const InvalidIndexException &e) {
+    EXPECT_STREQ(
+        e.what(),
+        "Hum... esse número não corresponde a nenhum conjunto. Poderia "
+        "verificar qual o índice correto?"); // Ajuste se a mensagem for
+                                             // diferente
+  } catch (...) {
+    FAIL()
+        << "Expected InvalidIndexException, but caught a different exception";
+  }
 }

--- a/test/ValidateOnlyIntegersTest.cpp
+++ b/test/ValidateOnlyIntegersTest.cpp
@@ -9,79 +9,83 @@
 using std::string;
 
 // Função a ser testada
-void ValidateOnlyIntegers(const string& str);
+void ValidateOnlyIntegers(const string &str);
 
 // Testa a validação de inteiros válidos
 TEST(ValidateOnlyIntegersTest, ValidInteger) {
-    // Testa números inteiros positivos
-    EXPECT_NO_THROW(ValidateOnlyIntegers("123"));
+  // Testa números inteiros positivos
+  EXPECT_NO_THROW(ValidateOnlyIntegers("123"));
 
-    // Testa números inteiros negativos
-    EXPECT_NO_THROW(ValidateOnlyIntegers("-123"));
+  // Testa números inteiros negativos
+  EXPECT_NO_THROW(ValidateOnlyIntegers("-123"));
 
-    // Testa número zero
-    EXPECT_NO_THROW(ValidateOnlyIntegers("0"));
+  // Testa número zero
+  EXPECT_NO_THROW(ValidateOnlyIntegers("0"));
 }
 
 // Testa entradas inválidas que devem lançar exceção
 TEST(ValidateOnlyIntegersTest, InvalidInteger) {
-    // Testa string com letras
-    EXPECT_THROW(ValidateOnlyIntegers("123abc"), InvalidNumberInputException);
+  // Testa string com letras
+  EXPECT_THROW(ValidateOnlyIntegers("123abc"), InvalidNumberInputException);
 
-    // Testa string com espaços
-    EXPECT_NO_THROW(ValidateOnlyIntegers("123 45"));
+  // Testa string com espaços
+  EXPECT_NO_THROW(ValidateOnlyIntegers("123 45"));
 
-    // Testa string com símbolos
-    EXPECT_THROW(ValidateOnlyIntegers("123$45"), InvalidNumberInputException);
+  // Testa string com símbolos
+  EXPECT_THROW(ValidateOnlyIntegers("123$45"), InvalidNumberInputException);
 
-    // Testa string com ponto decimal
-    EXPECT_THROW(ValidateOnlyIntegers("123.45"), InvalidNumberInputException);
+  // Testa string com ponto decimal
+  EXPECT_THROW(ValidateOnlyIntegers("123.45"), InvalidNumberInputException);
 
-    // Testa string vazia
-    EXPECT_NO_THROW(ValidateOnlyIntegers(""));
+  // Testa string vazia
+  EXPECT_NO_THROW(ValidateOnlyIntegers(""));
 
-    // Testa string com um sinal sem número (ex: "-")
-    EXPECT_THROW(ValidateOnlyIntegers("-"), InvalidNumberInputException);
+  // Testa string com um sinal sem número (ex: "-")
+  EXPECT_THROW(ValidateOnlyIntegers("-"), InvalidNumberInputException);
 }
 
 // Testa casos de números negativos
 TEST(ValidateOnlyIntegersTest, NegativeInteger) {
-    // Testa número negativo válido
-    EXPECT_NO_THROW(ValidateOnlyIntegers("-999"));
+  // Testa número negativo válido
+  EXPECT_NO_THROW(ValidateOnlyIntegers("-999"));
 
-    // Testa número negativo com espaço no meio (inválido)
-    EXPECT_THROW(ValidateOnlyIntegers("- 999"), InvalidNumberInputException);
+  // Testa número negativo com espaço no meio (inválido)
+  EXPECT_THROW(ValidateOnlyIntegers("- 999"), InvalidNumberInputException);
 
-    // Testa número negativo com letras (inválido)
-    EXPECT_THROW(ValidateOnlyIntegers("-abc"), InvalidNumberInputException);
+  // Testa número negativo com letras (inválido)
+  EXPECT_THROW(ValidateOnlyIntegers("-abc"), InvalidNumberInputException);
 
-    // Testa número negativo com símbolos (inválido)
-    EXPECT_THROW(ValidateOnlyIntegers("-123$"), InvalidNumberInputException);
+  // Testa número negativo com símbolos (inválido)
+  EXPECT_THROW(ValidateOnlyIntegers("-123$"), InvalidNumberInputException);
 }
 
 // Testa casos de entradas com caracteres não numéricos
 TEST(ValidateOnlyIntegersTest, NonNumericInput) {
-    // Testa entrada com letras
-    EXPECT_THROW(ValidateOnlyIntegers("hello"), InvalidNumberInputException);
+  // Testa entrada com letras
+  EXPECT_THROW(ValidateOnlyIntegers("hello"), InvalidNumberInputException);
 
-    // Testa entrada com caracteres especiais
-    EXPECT_THROW(ValidateOnlyIntegers("123!@#"), InvalidNumberInputException);
+  // Testa entrada com caracteres especiais
+  EXPECT_THROW(ValidateOnlyIntegers("123!@#"), InvalidNumberInputException);
 }
 
-// Testa strings que começam com números, mas têm caracteres não numéricos no final
+// Testa strings que começam com números, mas têm caracteres não numéricos no
+// final
 TEST(ValidateOnlyIntegersTest, ValidPrefixInvalidSuffix) {
-    // Testa que a string começa com números mas tem caracteres não numéricos no final
-    EXPECT_THROW(ValidateOnlyIntegers("123abc"), InvalidNumberInputException);
+  // Testa que a string começa com números mas tem caracteres não numéricos no
+  // final
+  EXPECT_THROW(ValidateOnlyIntegers("123abc"), InvalidNumberInputException);
 }
 
 // Testa a exceção correta sendo lançada
 TEST(ValidateOnlyIntegersTest, ThrowsExceptionWithInvalidInput) {
-    try {
-        ValidateOnlyIntegers("123abc");
-        FAIL() << "Expected InvalidNumberInputException to be thrown";
-    } catch (const InvalidNumberInputException& e) {
-        EXPECT_STREQ(e.what(), "Oops! Parece que você digitou algo além de números. Tente novamente, por favor.");
-    } catch (...) {
-        FAIL() << "Expected InvalidNumberInputException, but caught a different exception";
-    }
+  try {
+    ValidateOnlyIntegers("123abc");
+    FAIL() << "Expected InvalidNumberInputException to be thrown";
+  } catch (const InvalidNumberInputException &e) {
+    EXPECT_STREQ(e.what(), "Oops! Parece que você digitou algo além de "
+                           "números. Tente novamente, por favor.");
+  } catch (...) {
+    FAIL() << "Expected InvalidNumberInputException, but caught a different "
+              "exception";
+  }
 }


### PR DESCRIPTION
This pull request includes several changes to improve code consistency, readability, and formatting across multiple files. The most important updates include the adoption of a new code style, adjustments to inline formatting for constructors and type aliases, and the reorganization of `using` declarations.

### Code style and formatting:

* [`.clang-format`](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2R1): Introduced the `BasedOnStyle: LLVM` configuration to standardize code formatting across the project.

* `def/SetInfo.hpp`, `include/Commander/Commands/Command.hpp`, `def/StringValidatorArray.hpp`: Reformatted inline constructors and type aliases to fit on a single line for improved readability. [[1]](diffhunk://#diff-0381fb920ebc61337863ffd1d1a8732ac6597124361a78c57a886c44522fb52dL15-R15) [[2]](diffhunk://#diff-47891037a2d42dd9f32080edb21a4629de417834d4a5adffcb3db4b3e38669a2L23-R23) [[3]](diffhunk://#diff-3263e4dd77029f3acc63ee86c4d36e0b46ce7104b59658e3fbd69462fbe931fdL8-R8)

### Reorganization of `using` declarations:

* Multiple files in `include/Commander/Commands/`: Moved `using std::string` declarations to align with other `using` declarations and improve consistency across the codebase. This change affects files such as `ClearCommand.hpp`, `ContainsCommand.hpp`, `CreateCommand.hpp`, `EmptyCommand.hpp`, `HelpCommand.hpp`, `InsertCommand.hpp`, `MinimumCommand.hpp`, `ShowCommand.hpp`, `SizeCommand.hpp`, and `SwapCommand.hpp`. [[1]](diffhunk://#diff-925b0c47927323ce1121552ed4e053c7be37875491b4af9d70e84a77b938496dL6-R7) [[2]](diffhunk://#diff-3468ac070f49c22f3e3b3eb7ae2b7fba61e1c11cc9de9ad0c235088f4b31da65L6-R7) [[3]](diffhunk://#diff-45a6d8edb5d74067e7a86c645f6633ef63c7dd496a5a589ab6da999e1ae97eaeR4-R12) [[4]](diffhunk://#diff-b9eadec4d6238688bb25a5558bfbd5845d450b1ace4ff88f680bb78b57c5244eL6-R7) [[5]](diffhunk://#diff-233695772f2145c7cfa48e29fc0ec522dd9c7c92d04b1e835529880330577794L10-R11) [[6]](diffhunk://#diff-7488d02ce569bc10912bf50af90897572b4f64af95ebfb1edc7213f4a34987fcL6-R7) [[7]](diffhunk://#diff-b1ab96ae47579c7ac07ae1744c07422379f1c257b615cfe1c6a0229f8f119710L6-R7) [[8]](diffhunk://#diff-4556467883ee4209d6b598f82f6694426ea0ae9070419bcbafdf4d7fadc7f96fL7-R8) [[9]](diffhunk://#diff-78107d7d8d992485aa3cb3db7b25f398197671d06692cc6846e4fffbc1e8eb96L6-R7) [[10]](diffhunk://#diff-9c238ea76e04b833e57c2126c4ac3473b0f70f513499a5f832a3e383ca1bf6cdL9-R10)